### PR TITLE
Support pileup

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,3 +133,17 @@ make the web page
 ```
 python python/run.py --web --version v03
 ```
+
+
+
+WARNING
+===========
+
+Official installation of FCCSW does not support certain options (not yet in the release). Please check the following list for the recommended versions:
+
+```
+--mergePileup --local inits/pileup.py
+--estimatePileup --local inits/pileup.py
+--recPositions --local inits/reco.py
+--recTopoClusters --local inits/reco.py
+```

--- a/README.md
+++ b/README.md
@@ -103,6 +103,26 @@ python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --l
 python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --addPileupNoise --mu 100
 ```
 
+Pileup
+==============
+
+There are several approaches of addressing the pile-up in the detector:
+
+1. Apply noise in the detector that represents the noise introduced by the simultanous collisions. The offset in the energy deposit is assumed to be corrected for.
+
+- estimation of the pile-up noise per cell and per cluster (only in ECal detector at the moment) can be done using **--estimatePileup** job option.
+  It creates histograms filling in the information on the deposits per event. This can be later scaled with *sqrt(mu)* for the noise (RMS of the energy distributions) and with *mu* for the mean energy deposit.
+  Detailed analysis and this scaling is done with FCC_calo_analysis_cpp toolkit.
+
+- apply estimated noise levels at the cluster level for sliding window reconstruction or layer by layer for the topological clusters (**--addPileupNoise**).
+
+2. Mix already simulated events in order to overlay:
+
+- cells that are later passed to the reconstruction (**--mergePileup**)
+
+- or clusters that can be directly analysed (not yet supported)
+
+
 Miscellaneous
 ==============
 Formatting rules:

--- a/config/geantSim.py
+++ b/config/geantSim.py
@@ -185,7 +185,7 @@ else:
     pythia8gen = GenAlg("Pythia8", SignalProvider=pythia8gentool, VertexSmearingTool=smeartool)
     pythia8gen.hepmc.Path = "hepmc"
     from Configurables import HepMCToEDMConverter
-    hepmc_converter = HepMCToEDMConverter("Converter")
+    hepmc_converter = HepMCToEDMConverter("Converter", hepmcStatusList=[]) # save all the particles from Pythia
     hepmc_converter.hepmc.Path="hepmc"
     hepmc_converter.genparticles.Path="allGenParticles"
     hepmc_converter.genvertices.Path="GenVertices"

--- a/config/geantSim.py
+++ b/config/geantSim.py
@@ -5,6 +5,7 @@ simparser.add_argument("--bFieldOff", action='store_true', help="Switch OFF magn
 simparser.add_argument('-s','--seed', type=int, help='Seed for the random number generator', required=True)
 simparser.add_argument('-N','--numEvents', type=int, help='Number of simulation events to run', required=True)
 simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
 
 
 genTypeGroup = simparser.add_mutually_exclusive_group(required = True) # Type of events to generate
@@ -34,10 +35,12 @@ magnetic_field = not simargs.bFieldOff
 num_events = simargs.numEvents
 seed = simargs.seed
 output_name = simargs.outName
+path_to_detector = simargs.detectorPath
 print "B field: ", magnetic_field
 print "number of events = ", num_events
 print "seed: ", seed
 print "output name: ", output_name
+print "detectors are taken from: ", path_to_detector
 if simargs.singlePart:
     energy = simargs.energy
     etaMin = simargs.etaMin
@@ -73,7 +76,6 @@ from GaudiKernel import SystemOfUnits as units
 ##############################################################################################################
 #######                                         GEOMETRY                                         #############
 ##############################################################################################################
-path_to_detector = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj"
 detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                   path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
                   path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
@@ -95,9 +97,7 @@ ecalEndcapReadoutName = "EMECPhiEta"
 ecalFwdReadoutName = "EMFwdPhiEta"
 # HCAL readouts
 hcalBarrelReadoutName = "HCalBarrelReadout"
-hcalBarrelReadoutNamePhiEta = hcalBarrelReadoutName + "_phieta"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
-hcalExtBarrelReadoutNamePhiEta = hcalExtBarrelReadoutName + "_phieta"
 hcalEndcapReadoutName = "HECPhiEta"
 hcalFwdReadoutName = "HFwdPhiEta"
 # Tail Catcher readout
@@ -209,7 +209,7 @@ else:
 from Configurables import CalibrateInLayersTool, CalibrateCaloHitsTool
 calibEcalBarrel = CalibrateInLayersTool("CalibrateEcalBarrel",
                                         # sampling fraction obtained using SamplingFractionInLayers from DetStudies package
-                                        samplingFraction = [0.12125] + [0.14283] + [0.16354] + [0.17662] + [0.18867] + [0.19890] + [0.20637] + [0.20802],
+                                        samplingFraction = [0.299041341789] + [0.1306220735]+ [0.163243999965]  + [0.186360269398] + [0.203778124831] + [0.216211280314] + [0.227140796653] + [0.243315422934],
                                         readoutName = ecalBarrelReadoutName,
                                         layerFieldName = "layer")
 calibHcells = CalibrateCaloHitsTool("CalibrateHCal", invSamplingFraction="41.66")

--- a/config/overlayPileup.py
+++ b/config/overlayPileup.py
@@ -1,0 +1,215 @@
+import argparse
+simparser = argparse.ArgumentParser()
+simparser.add_argument('--inName', type=str, nargs = "+", help='Name of the input file', required=True)
+simparser.add_argument('--inSignalName', type=str, help='Name of the input file with signal')
+simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('-N','--numEvents', type=int, help='Number of simulation events to run', required=True)
+simparser.add_argument('--pileup', type=int, help='Pileup', default = 1000)
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
+simargs, _ = simparser.parse_known_args()
+
+print "=================================="
+print "==      GENERAL SETTINGS       ==="
+print "=================================="
+num_events = simargs.numEvents
+path_to_detector = simargs.detectorPath
+print "detectors are taken from: ", path_to_detector
+input_name = simargs.inName
+if simargs.inSignalName:
+    input_signal_name = simargs.inSignalName
+    print "input signal name: ", input_name
+output_name = simargs.outName
+print "input pileup name: ", input_name
+print "output name: ", output_name
+print "=================================="
+
+from Gaudi.Configuration import *
+
+# list of names of files with pileup event data -- to be overlaid
+pileupFilenames = input_name
+# the file containing the signal events
+if simargs.inSignalName:
+    signalFilename = input_signal_name
+    noSignal = False
+    # the collections to be read from the signal event
+    signalCollections = ["GenParticles", "GenVertices",
+                         "ECalBarrelCells", "ECalEndcapCells", "ECalFwdCells",
+                         "HCalBarrelCells", "HCalExtBarrelCells", "HCalEndcapCells", "HCalFwdCells"]
+    # Data service
+    from Configurables import FCCDataSvc
+    podioevent = FCCDataSvc("EventDataSvc", input=signalFilename)
+    # use PodioInput for Signal
+    from Configurables import PodioInput
+    podioinput = PodioInput("PodioReader", collections=signalCollections, OutputLevel=DEBUG)
+    list_of_algorithms = [podioevent]
+else:
+    signalFilename = ""
+    noSignal = True
+    list_of_algorithms = []
+    from Configurables import FCCDataSvc
+    podioevent = FCCDataSvc("EventDataSvc")
+print signalFilename, noSignal
+
+
+
+##############################################################################################################
+#######                                         GEOMETRY                                         #############
+##############################################################################################################
+path_to_detector = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj"
+detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                  path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
+                  path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
+                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
+                  path_to_detector+'/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml',
+                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
+                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Shielding.xml']
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
+
+
+# edm data from generation: particles and vertices
+from Configurables import PileupParticlesMergeTool
+particlemergetool = PileupParticlesMergeTool("ParticlesMerge")
+# branchnames for the pileup
+particlemergetool.genParticlesBranch = "GenParticles"
+particlemergetool.genVerticesBranch = "GenVertices"
+# branchnames for the signal
+particlemergetool.signalGenParticles.Path = "GenParticles"
+particlemergetool.signalGenVertices.Path = "GenVertices"
+# branchnames for the output
+particlemergetool.mergedGenParticles.Path = "pileupGenParticles"
+particlemergetool.mergedGenVertices.Path = "pileupGenVertices"
+
+# edm data from simulation: hits and positioned hits
+from Configurables import PileupCaloHitMergeTool
+ecalbarrelmergetool = PileupCaloHitMergeTool("ECalBarrelHitMerge")
+ecalbarrelmergetool.pileupHitsBranch = "ECalBarrelCells"
+ecalbarrelmergetool.signalHits = "ECalBarrelCells"
+ecalbarrelmergetool.mergedHits = "pileupECalBarrelCells"
+
+# edm data from simulation: hits and positioned hits
+ecalendcapmergetool = PileupCaloHitMergeTool("ECalEndcapHitMerge")
+ecalendcapmergetool.pileupHitsBranch = "ECalEndcapCells"
+ecalendcapmergetool.signalHits = "ECalEndcapCells"
+ecalendcapmergetool.mergedHits = "pileupECalEndcapCells"
+
+# edm data from simulation: hits and positioned hits
+ecalfwdmergetool = PileupCaloHitMergeTool("ECalFwdHitMerge")
+# branchnames for the pileup
+ecalfwdmergetool.pileupHitsBranch = "ECalFwdCells"
+ecalfwdmergetool.signalHits = "ECalFwdCells"
+ecalfwdmergetool.mergedHits = "pileupECalFwdCells"
+
+# edm data from simulation: hits and positioned hits
+hcalbarrelmergetool = PileupCaloHitMergeTool("HCalBarrelHitMerge")
+hcalbarrelmergetool.pileupHitsBranch = "HCalBarrelCells"
+hcalbarrelmergetool.signalHits = "HCalBarrelCells"
+hcalbarrelmergetool.mergedHits = "pileupHCalBarrelCells"
+
+# edm data from simulation: hits and positioned hits
+hcalextbarrelmergetool = PileupCaloHitMergeTool("HCalExtBarrelHitMerge")
+hcalextbarrelmergetool.pileupHitsBranch = "HCalExtBarrelCells"
+hcalextbarrelmergetool.signalHits = "HCalExtBarrelCells"
+hcalextbarrelmergetool.mergedHits = "pileupHCalExtBarrelCells"
+
+# edm data from simulation: hits and positioned hits
+hcalfwdmergetool = PileupCaloHitMergeTool("HCalFwdHitMerge")
+hcalfwdmergetool.pileupHitsBranch = "HCalFwdCells"
+hcalfwdmergetool.signalHits = "HCalFwdCells"
+hcalfwdmergetool.mergedHits = "pileupHCalFwdCells"
+
+# edm data from simulation: hits and positioned hits
+hcalfwdmergetool = PileupCaloHitMergeTool("HCalEndcapHitMerge")
+hcalfwdmergetool.pileupHitsBranch = "HCalEndcapCells"
+hcalfwdmergetool.signalHits = "HCalEndcapCells"
+hcalfwdmergetool.mergedHits = "pileupHCalEndcapCells"
+
+# use the pileuptool to specify the number of pileup
+from Configurables import ConstPileUp
+pileuptool = ConstPileUp("MyPileupTool", numPileUpEvents=simargs.pileup)
+
+# algorithm for the overlay
+from Configurables import PileupOverlayAlg
+overlay = PileupOverlayAlg()
+overlay.pileupFilenames = pileupFilenames
+overlay.randomizePileup = True
+overlay.mergeTools = ["PileupParticlesMergeTool/ParticlesMerge",
+  "PileupCaloHitMergeTool/ECalBarrelHitMerge",
+  "PileupCaloHitMergeTool/ECalEndcapHitMerge",
+  "PileupCaloHitMergeTool/ECalFwdHitMerge",
+  "PileupCaloHitMergeTool/HCalBarrelHitMerge",
+  "PileupCaloHitMergeTool/HCalExtBarrelHitMerge",
+  "PileupCaloHitMergeTool/HCalEndcapHitMerge",
+  "PileupCaloHitMergeTool/HCalFwdHitMerge"]
+overlay.PileUpTool = pileuptool
+overlay.noSignal = noSignal
+
+
+##############################################################################################################
+#######                                       DIGITISATION                                       #############
+##############################################################################################################
+from Configurables import CreateCaloCells
+createEcalBarrelCells = CreateCaloCells("CreateEcalBarrelCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createEcalBarrelCells.hits.Path="pileupECalBarrelCells"
+createEcalBarrelCells.cells.Path="mergedECalBarrelCells"
+createEcalEndcapCells = CreateCaloCells("CreateEcalEndcapCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createEcalEndcapCells.hits.Path="pileupECalEndcapCells"
+createEcalEndcapCells.cells.Path="mergedECalEndcapCells"
+createEcalFwdCells = CreateCaloCells("CreateEcalFwdCells",
+                                     doCellCalibration=False,
+                                     addCellNoise=False, filterCellNoise=False)
+createEcalFwdCells.hits.Path="pileupECalFwdCells"
+createEcalFwdCells.cells.Path="mergedECalFwdCells"
+createHcalBarrelCells = CreateCaloCells("CreateHcalBarrelCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createHcalBarrelCells.hits.Path="pileupHCalBarrelCells"
+createHcalBarrelCells.cells.Path="mergedHCalBarrelCells"
+createHcalExtBarrelCells = CreateCaloCells("CreateHcalExtBarrelCells",
+                                           doCellCalibration=False,
+                                           addCellNoise=False, filterCellNoise=False)
+createHcalExtBarrelCells.hits.Path="pileupHCalExtBarrelCells"
+createHcalExtBarrelCells.cells.Path="mergedHCalExtBarrelCells"
+createHcalEndcapCells = CreateCaloCells("CreateHcalEndcapCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createHcalEndcapCells.hits.Path="pileupHCalEndcapCells"
+createHcalEndcapCells.cells.Path="mergedHCalEndcapCells"
+createHcalFwdCells = CreateCaloCells("CreateHcalFwdCells",
+                                     doCellCalibration=False,
+                                     addCellNoise=False, filterCellNoise=False)
+createHcalFwdCells.hits.Path="pileupHCalFwdCells"
+createHcalFwdCells.cells.Path="mergedHCalFwdCells"
+
+# PODIO algorithm
+from Configurables import PodioOutput
+out = PodioOutput("out")
+out.outputCommands = ["drop *", "keep mergedECalBarrelCells", "keep mergedECalEndcapCells", "keep mergedECalFwdCells", "keep mergedHCalBarrelCells", "keep mergedHCalExtBarrelCells", "keep mergedHCalEndcapCells", "keep mergedHCalFwdCells"]
+out.filename = output_name
+
+list_of_algorithms += [overlay,
+                       createEcalBarrelCells,
+                       createEcalEndcapCells,
+                       createEcalFwdCells,
+                       createHcalBarrelCells,
+                       createHcalExtBarrelCells,
+                       createHcalEndcapCells,
+                       createHcalFwdCells,
+                       out
+                       ]
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg=list_of_algorithms,
+                EvtSel='NONE',
+                EvtMax=num_events,
+                ExtSvc=[geoservice, podioevent]
+ )

--- a/config/preparePileup.py
+++ b/config/preparePileup.py
@@ -83,7 +83,7 @@ pileupEcalBarrel = PreparePileup("PreparePileupEcalBarrel",
                                  histogramName = "ecalBarrelEnergyVsAbsEta",
                                  numLayers = 8,
                                  etaSize = [7,  5,  7,   9,    3,      3],
-                                 phiSize = [17,15, 21, 21,  15,  11])
+                                 phiSize = [19,15, 21, 21,  15,  11])
 pileupEcalBarrel.hits.Path="ECalBarrelCells"
 
 THistSvc().Output = ["rec DATAFILE='" + output_name + "' TYP='ROOT' OPT='RECREATE'"]

--- a/config/preparePileup.py
+++ b/config/preparePileup.py
@@ -1,0 +1,110 @@
+import argparse
+simparser = argparse.ArgumentParser()
+simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
+simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
+simargs, _ = simparser.parse_known_args()
+
+print "=================================="
+print "==      GENERAL SETTINGS       ==="
+print "=================================="
+input_name = simargs.inName
+output_name = simargs.outName
+path_to_detector = simargs.detectorPath
+print "detectors are taken from: ", path_to_detector
+print "input name: ", input_name
+print "output name: ", output_name
+print "=================================="
+
+from Gaudi.Configuration import *
+
+from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
+
+# v01 production - min. bias events
+podioevent = FCCDataSvc("EventDataSvc", input=input_name)
+
+from Configurables import PodioInput
+
+podioinput = PodioInput("in", collections = ["ECalBarrelCells"])
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = [ path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                  path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
+],
+                    OutputLevel = WARNING)
+
+# Pileup in ECal Barrel
+# readout name
+ecalBarrelReadoutNamePhiEta = "ECalBarrelPhiEta"
+# hcalBarrelReadoutNamePhiEta = "BarHCal_Readout_phieta"
+
+# geometry tool
+from Configurables import TubeLayerPhiEtaCaloTool
+ecalBarrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
+                                             readoutName = ecalBarrelReadoutNamePhiEta,
+                                             activeVolumeName = "LAr_sensitive",
+                                             activeFieldName = "layer",
+                                             fieldNames = ["system"],
+                                             fieldValues = [5],
+                                             activeVolumesNumber = 8)
+
+from Configurables import CreateEmptyCaloCellsCollection
+createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
+createemptycells.cells.Path = "emptyCaloCells"
+#Create calo clusters
+from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
+from GaudiKernel.PhysicalConstants import pi
+
+towers = CaloTowerTool("towers",
+                               deltaEtaTower = 0.01, deltaPhiTower = 2*pi/704.,
+                               ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
+                               ecalEndcapReadoutName = "",
+                               ecalFwdReadoutName = "",
+                               hcalBarrelReadoutName = "",
+                               hcalExtBarrelReadoutName = "",
+                               hcalEndcapReadoutName = "",
+                               hcalFwdReadoutName = "")
+towers.ecalBarrelCells.Path = "ECalBarrelCells"
+towers.ecalEndcapCells.Path = "emptyCaloCells"
+towers.ecalFwdCells.Path = "emptyCaloCells"
+towers.hcalBarrelCells.Path = "emptyCaloCells"
+towers.hcalExtBarrelCells.Path = "emptyCaloCells"
+towers.hcalEndcapCells.Path = "emptyCaloCells"
+towers.hcalFwdCells.Path = "emptyCaloCells"
+
+# call pileup tool
+# prepare TH2 histogram with pileup per abs(eta)
+from Configurables import PreparePileup
+pileupEcalBarrel = PreparePileup("PreparePileupEcalBarrel",
+                                 geometryTool = ecalBarrelGeometry,
+                                 readoutName = ecalBarrelReadoutNamePhiEta,
+                                 layerFieldName = "layer",
+                                 towerTool = towers,
+                                 histogramName = "ecalBarrelEnergyVsAbsEta",
+                                 numLayers = 8,
+                                 etaSize = [7,  5,  7,   9,    3,      3],
+                                 phiSize = [17,15, 21, 21,  15,  11])
+pileupEcalBarrel.hits.Path="ECalBarrelCells"
+
+THistSvc().Output = ["rec DATAFILE='" + output_name + "' TYP='ROOT' OPT='RECREATE'"]
+THistSvc().PrintAll=True
+THistSvc().AutoSave=True
+THistSvc().AutoFlush=True
+THistSvc().OutputLevel=INFO
+
+#CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+podioinput.AuditExecute = True
+
+ApplicationMgr(
+    TopAlg = [podioinput,
+              createemptycells,
+              pileupEcalBarrel,
+              ],
+    EvtSel = 'NONE',
+    EvtMax = -1,
+    ExtSvc = [podioevent, geoservice],
+ )

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -5,7 +5,7 @@ simparser.add_argument('--inName', type=str, help='Name of the input file', requ
 simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
 simparser.add_argument('-N','--numEvents',  type=int, help='Number of simulation events to run', required=True)
 simparser.add_argument('--prefixCollections', type=str, help='Prefix added to the collection names', default="")
-simparser.add_argument("--addMuons", action='store_true', help="Add tail catcher cells", default = True)
+simparser.add_argument("--addMuons", action='store_true', help="Add tail catcher cells", default = False)
 
 simargs, _ = simparser.parse_known_args()
 

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -4,6 +4,8 @@ simparser = argparse.ArgumentParser()
 simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
 simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
 simparser.add_argument('-N','--numEvents',  type=int, help='Number of simulation events to run', required=True)
+simparser.add_argument('--prefixCollections', type=str, help='Prefix added to the collection names', default="")
+simparser.add_argument("--addMuons", action='store_true', help="Add tail catcher cells", default = True)
 
 simargs, _ = simparser.parse_known_args()
 
@@ -13,9 +15,12 @@ print "=================================="
 num_events = simargs.numEvents
 input_name = simargs.inName
 output_name = simargs.outName
+prefix = simargs.prefixCollections
+addMuons = simargs.addMuons
 print "number of events = ", num_events
 print "input name: ", input_name
 print "output name: ", output_name
+print "prefix added to the collections' name: ", prefix
 
 from Gaudi.Configuration import *
 ##############################################################################################################
@@ -54,23 +59,14 @@ tailCatcherReadoutName = "Muons_Readout"
 from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
 podioevent = FCCDataSvc("EventDataSvc", input=input_name)
 
-podioinput = PodioInput("PodioReader", collections = ["TrackerPositionedHits","ECalBarrelCells", "HCalBarrelCells", "HCalExtBarrelCells", "ECalEndcapCells", "HCalEndcapCells", "ECalFwdCells", "HCalFwdCells", "TailCatcherCells","GenParticles","GenVertices"], OutputLevel = DEBUG)
+coll_names_read = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", prefix+"HCalExtBarrelCells", prefix+"ECalEndcapCells", prefix+"HCalEndcapCells", prefix+"ECalFwdCells", prefix+"HCalFwdCells"]
+if addMuons:
+    coll_names_read += ["TailCatcherCells"]
+podioinput = PodioInput("PodioReader", collections = coll_names_read, OutputLevel = DEBUG)
 
-##############################################################################################################                                                                                                                                
-#######                                       RECALIBRATE ECAL                                   #############                                                                                                                                
-##############################################################################################################                                                                                                                                
-
-from Configurables import CalibrateInLayersTool, CreateCaloCells
-recalibEcalBarrel = CalibrateInLayersTool("RecalibrateEcalBarrel",
-                                          samplingFraction = [0.299654475899/0.12125] + [0.148166996525/0.14283] + [0.163005489744/0.16354] + [0.176907220821/0.17662] + [0.189980731321/0.18867] + [0.202201963561/0.19890] + [0.214090761907/0.20637] + [0.224706564289/0.20802],
-                                          readoutName = ecalBarrelReadoutName,
-                                          layerFieldName = "layer")
-recreateEcalBarrelCells = CreateCaloCells("redoEcalBarrelCells",
-                                          doCellCalibration=True,
-                                          calibTool=recalibEcalBarrel,
-                                          addCellNoise=False, filterCellNoise=False)
-recreateEcalBarrelCells.hits.Path="ECalBarrelCells"
-recreateEcalBarrelCells.cells.Path="ECalBarrelCellsRedo"
+##############################################################################################################
+#######                                       RECALIBRATE ECAL                                   #############
+##############################################################################################################
 
 from Configurables import RewriteBitfield
 rewriteECalEC = RewriteBitfield("RewriteECalEC",
@@ -83,7 +79,7 @@ rewriteECalEC = RewriteBitfield("RewriteECalEC",
                                 debugPrint = 10,
                                 OutputLevel = DEBUG)
 # clusters are needed, with deposit position and cellID in bits
-rewriteECalEC.inhits.Path = "ECalEndcapCells"
+rewriteECalEC.inhits.Path = prefix+"ECalEndcapCells"
 rewriteECalEC.outhits.Path = "newECalEndcapCells"
 
 rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
@@ -96,7 +92,7 @@ rewriteHCalEC = RewriteBitfield("RewriteHCalEC",
                                 debugPrint = 10,
                                 OutputLevel = DEBUG)
 # clusters are needed, with deposit position and cellID in bits
-rewriteHCalEC.inhits.Path = "HCalEndcapCells"
+rewriteHCalEC.inhits.Path = prefix+"HCalEndcapCells"
 rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
 
 ##############################################################################################################
@@ -104,79 +100,84 @@ rewriteHCalEC.outhits.Path = "newHCalEndcapCells"
 ##############################################################################################################
 
 #Configure tools for calo cell positions
-from Configurables import CellPositionsECalBarrelTool, CellPositionsHCalBarrelNoSegTool, CellPositionsCaloDiscsTool, CellPositionsCaloDiscsTool, CellPositionsTailCatcherTool 
-ECalBcells = CellPositionsECalBarrelTool("CellPositionsECalBarrel", 
-                                    readoutName = ecalBarrelReadoutName, 
+from Configurables import CellPositionsECalBarrelTool, CellPositionsHCalBarrelNoSegTool, CellPositionsCaloDiscsTool, CellPositionsCaloDiscsTool
+ECalBcells = CellPositionsECalBarrelTool("CellPositionsECalBarrel",
+                                    readoutName = ecalBarrelReadoutName,
                                     OutputLevel = INFO)
-EMECcells = CellPositionsCaloDiscsTool("CellPositionsEMEC", 
-                                    readoutName = ecalEndcapReadoutName, 
+EMECcells = CellPositionsCaloDiscsTool("CellPositionsEMEC",
+                                    readoutName = ecalEndcapReadoutName,
                                     OutputLevel = DEBUG)
-ECalFwdcells = CellPositionsCaloDiscsTool("CellPositionsECalFwd", 
-                                        readoutName = ecalFwdReadoutName, 
+ECalFwdcells = CellPositionsCaloDiscsTool("CellPositionsECalFwd",
+                                        readoutName = ecalFwdReadoutName,
                                         OutputLevel = INFO)
-HCalBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalBarrel", 
-                                              readoutName = hcalBarrelReadoutName, 
+HCalBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalBarrel",
+                                              readoutName = hcalBarrelReadoutName,
                                               OutputLevel = INFO)
-HCalExtBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalExtBarrel", 
-                                                 readoutName = hcalExtBarrelReadoutName, 
+HCalExtBcells = CellPositionsHCalBarrelNoSegTool("CellPositionsHCalExtBarrel",
+                                                 readoutName = hcalExtBarrelReadoutName,
                                                  OutputLevel = INFO)
-HECcells = CellPositionsCaloDiscsTool("CellPositionsHEC", 
-                                   readoutName = hcalEndcapReadoutName, 
+HECcells = CellPositionsCaloDiscsTool("CellPositionsHEC",
+                                   readoutName = hcalEndcapReadoutName,
                                    OutputLevel = INFO)
-HCalFwdcells = CellPositionsCaloDiscsTool("CellPositionsHCalFwd", 
-                                        readoutName = hcalFwdReadoutName, 
+HCalFwdcells = CellPositionsCaloDiscsTool("CellPositionsHCalFwd",
+                                        readoutName = hcalFwdReadoutName,
                                         OutputLevel = INFO)
-TailCatchercells = CellPositionsTailCatcherTool("CellPositionsTailCatcher", 
-                                                readoutName = tailCatcherReadoutName, 
-                                                centralRadius = 901.5,
-                                                OutputLevel = INFO)
+if addMuons:
+    from Configurables import CellPositionsTailCatcherTool
+    TailCatchercells = CellPositionsTailCatcherTool("CellPositionsTailCatcher",
+                                                    readoutName = tailCatcherReadoutName,
+                                                    centralRadius = 901.5,
+                                                    OutputLevel = INFO)
 
 # cell positions
 from Configurables import CreateCellPositions
-positionsEcalBarrel = CreateCellPositions("positionsEcalBarrel", 
-                                          positionsTool=ECalBcells, 
-                                          hits = "ECalBarrelCellsRedo", 
-                                          positionedHits = "ECalBarrelCellPositions", 
+positionsEcalBarrel = CreateCellPositions("positionsEcalBarrel",
+                                          positionsTool=ECalBcells,
+                                          hits = prefix+"ECalBarrelCells",
+                                          positionedHits = "ECalBarrelCellPositions",
                                           OutputLevel = INFO)
-positionsHcalBarrel = CreateCellPositions("positionsHcalBarrel", 
-                                          positionsTool=HCalBcells, 
-                                          hits = "HCalBarrelCells", 
-                                          positionedHits = "HCalBarrelCellPositions", 
+positionsHcalBarrel = CreateCellPositions("positionsHcalBarrel",
+                                          positionsTool=HCalBcells,
+                                          hits = prefix+"HCalBarrelCells",
+                                          positionedHits = "HCalBarrelCellPositions",
                                           OutputLevel = INFO)
-positionsHcalExtBarrel = CreateCellPositions("positionsHcalExtBarrel", 
-                                          positionsTool=HCalExtBcells, 
-                                          hits = "HCalExtBarrelCells", 
-                                          positionedHits = "HCalExtBarrelCellPositions", 
+positionsHcalExtBarrel = CreateCellPositions("positionsHcalExtBarrel",
+                                          positionsTool=HCalExtBcells,
+                                          hits = prefix+"HCalExtBarrelCells",
+                                          positionedHits = "HCalExtBarrelCellPositions",
                                           OutputLevel = INFO)
-positionsEcalEndcap = CreateCellPositions("positionsEcalEndcap", 
-                                          positionsTool=EMECcells, 
-                                          hits = "newECalEndcapCells", 
-                                          positionedHits = "ECalEndcapCellPositions", 
+positionsEcalEndcap = CreateCellPositions("positionsEcalEndcap",
+                                          positionsTool=EMECcells,
+                                          hits = "newECalEndcapCells",
+                                          positionedHits = "ECalEndcapCellPositions",
                                           OutputLevel = INFO)
-positionsHcalEndcap = CreateCellPositions("positionsHcalEndcap", 
-                                          positionsTool=HECcells, 
-                                          hits = "newHCalEndcapCells", 
-                                          positionedHits = "HCalEndcapCellPositions", 
+positionsHcalEndcap = CreateCellPositions("positionsHcalEndcap",
+                                          positionsTool=HECcells,
+                                          hits = "newHCalEndcapCells",
+                                          positionedHits = "HCalEndcapCellPositions",
                                           OutputLevel = INFO)
-positionsEcalFwd = CreateCellPositions("positionsEcalFwd", 
-                                          positionsTool=ECalFwdcells, 
-                                          hits = "ECalFwdCells", 
-                                          positionedHits = "ECalFwdCellPositions", 
+positionsEcalFwd = CreateCellPositions("positionsEcalFwd",
+                                          positionsTool=ECalFwdcells,
+                                          hits = prefix+"ECalFwdCells",
+                                          positionedHits = "ECalFwdCellPositions",
                                           OutputLevel = INFO)
-positionsHcalFwd = CreateCellPositions("positionsHcalFwd", 
-                                          positionsTool=HCalFwdcells, 
-                                          hits = "HCalFwdCells", 
-                                          positionedHits = "HCalFwdCellPositions", 
+positionsHcalFwd = CreateCellPositions("positionsHcalFwd",
+                                          positionsTool=HCalFwdcells,
+                                          hits = prefix+"HCalFwdCells",
+                                          positionedHits = "HCalFwdCellPositions",
                                           OutputLevel = INFO)
-positionsTailCatcher = CreateCellPositions("positionsTailCatcher", 
-                                          positionsTool=TailCatchercells, 
-                                          hits = "TailCatcherCells", 
-                                          positionedHits = "TailCatcherCellPositions", 
-                                          OutputLevel = INFO)
+if addMuons:
+    positionsTailCatcher = CreateCellPositions("positionsTailCatcher",
+                                               positionsTool=TailCatchercells,
+                                               hits = "TailCatcherCells",
+                                               positionedHits = "TailCatcherCellPositions",
+                                               OutputLevel = INFO)
 
 # PODIO algorithm
 out = PodioOutput("out", OutputLevel=DEBUG)
-out.outputCommands = ["keep *","drop ECalBarrelCells","drop ECalEndcapCells","drop ECalFwdCells","drop HCalBarrelCells", "drop HCalExtBarrelCells", "drop HCalEndcapCells", "drop HCalFwdCells", "drop TailCatcherCells"]
+out.outputCommands = ["keep *","drop "+prefix+"ECalBarrelCells","drop "+prefix+"ECalEndcapCells","drop "+prefix+"ECalFwdCells","drop "+prefix+"HCalBarrelCells", "drop "+prefix+"HCalExtBarrelCells", "drop "+prefix+"HCalEndcapCells", "drop "+prefix+"HCalFwdCells"]
+if addMuons:
+    out.outputCommands += ["drop TailCatcherCells"]
 out.filename = "edm.root"
 
 #CPU information
@@ -185,7 +186,6 @@ chra = ChronoAuditor()
 audsvc = AuditorSvc()
 audsvc.Auditors = [chra]
 podioinput.AuditExecute = True
-recreateEcalBarrelCells.AuditExecute = True
 positionsEcalBarrel.AuditExecute = True
 positionsEcalEndcap.AuditExecute = True
 positionsEcalFwd.AuditExecute = True
@@ -193,22 +193,23 @@ positionsHcalBarrel.AuditExecute = True
 positionsHcalExtBarrel.AuditExecute = True
 positionsHcalEndcap.AuditExecute = True
 positionsHcalFwd.AuditExecute = True
-positionsTailCatcher.AuditExecute = True
+if addMuons:
+    positionsTailCatcher.AuditExecute = True
 out.AuditExecute = True
 
 list_of_algorithms = [podioinput,
-                      recreateEcalBarrelCells,
                       rewriteECalEC,
                       rewriteHCalEC,
                       positionsEcalBarrel,
                       positionsEcalEndcap,
-                      positionsEcalFwd, 
-                      positionsHcalBarrel, 
-                      positionsHcalExtBarrel, 
-                      positionsHcalEndcap, 
-                      positionsHcalFwd,
-                      positionsTailCatcher,
-                      out]
+                      positionsEcalFwd,
+                      positionsHcalBarrel,
+                      positionsHcalExtBarrel,
+                      positionsHcalEndcap,
+                      positionsHcalFwd]
+if addMuons:
+    list_of_algorithms += [positionsTailCatcher]
+list_of_algorithms += [out]
 
 ApplicationMgr(
     TopAlg = list_of_algorithms,

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -179,8 +179,8 @@ towers = CaloTowerTool("towers",
 towers.ecalBarrelCells.Path = "ECalBarrelCells"
 towers.ecalEndcapCells.Path = "ECalEndcapCells"
 towers.ecalFwdCells.Path = "ECalFwdCells"
-towersNoiseP.hcalBarrelCells.Path = "HCalBarrelCells"
-towersNoiseP.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
+towers.hcalBarrelCells.Path = "HCalBarrelCells"
+towers.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
 towers.hcalEndcapCells.Path = "HCalEndcapCells"
 towers.hcalFwdCells.Path = "HCalFwdCells"
 

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -62,9 +62,7 @@ ecalBarrelPileupHistName = "h_pileup_layer"
 ecalEndcapNoiseHistName = "h_elecNoise_fcc_"
 # HCAL readouts
 hcalBarrelReadoutName = "HCalBarrelReadout"
-hcalBarrelReadoutNamePhiEta = "BarHCal_Readout_phieta"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
-hcalExtBarrelReadoutNamePhiEta = "ExtBarHCal_Readout_phieta"
 hcalEndcapReadoutName = "HECPhiEta"
 hcalFwdReadoutName = "HFwdPhiEta"
 ##############################################################################################################
@@ -86,6 +84,10 @@ podioinput = PodioInput("in", collections = ["GenVertices",
 ##############################################################################################################
 #######                                       DIGITISATION                                       #############
 ##############################################################################################################
+from Configurables import CreateEmptyCaloCellsCollection
+createemptycells = CreateEmptyCaloCellsCollection("CreateEmptyCaloCells")
+createemptycells.cells.Path = "emptyCaloCells"
+
 from Configurables import CreateCaloCells
 if noise:
     from Configurables import NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool
@@ -144,15 +146,19 @@ if noise:
                            ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                            ecalEndcapReadoutName = ecalEndcapReadoutName,
                            ecalFwdReadoutName = ecalFwdReadoutName,
-                           hcalBarrelReadoutName = hcalBarrelReadoutName,
-                           hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
+                           # hcalBarrelReadoutName = hcalBarrelReadoutName,
+                           # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
+                           hcalBarrelReadoutName = "",
+                           hcalExtBarrelReadoutName = "",
                            hcalEndcapReadoutName = hcalEndcapReadoutName,
                            hcalFwdReadoutName = hcalFwdReadoutName)
     towersNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     towersNoise.ecalEndcapCells.Path = "ECalEndcapCells"
     towersNoise.ecalFwdCells.Path = "ECalFwdCells"
-    towersNoise.hcalBarrelCells.Path = "HCalBarrelCells"
-    towersNoise.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
+    # towersNoise.hcalBarrelCells.Path = "HCalBarrelCells"
+    # towersNoise.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
+    towersNoise.hcalBarrelCells.Path = "emptyCaloCells"
+    towersNoise.hcalExtBarrelCells.Path = "emptyCaloCells"
     towersNoise.hcalEndcapCells.Path = "HCalEndcapCells"
     towersNoise.hcalFwdCells.Path = "HCalFwdCells"
     createclustersNoise = CreateCaloClustersSlidingWindow("CreateCaloClustersNoise",
@@ -172,15 +178,19 @@ towers = CaloTowerTool("towers",
                        ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                        ecalEndcapReadoutName = ecalEndcapReadoutName,
                        ecalFwdReadoutName = ecalFwdReadoutName,
-                       hcalBarrelReadoutName = hcalBarrelReadoutName,
-                       hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
+                       # hcalBarrelReadoutName = hcalBarrelReadoutName,
+                       # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
+                       hcalBarrelReadoutName = "",
+                       hcalExtBarrelReadoutName = "",
                        hcalEndcapReadoutName = hcalEndcapReadoutName,
                        hcalFwdReadoutName = hcalFwdReadoutName)
 towers.ecalBarrelCells.Path = "ECalBarrelCells"
 towers.ecalEndcapCells.Path = "ECalEndcapCells"
 towers.ecalFwdCells.Path = "ECalFwdCells"
-towers.hcalBarrelCells.Path = "HCalBarrelCells"
-towers.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
+# towers.hcalBarrelCells.Path = "HCalBarrelCells"
+# towers.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
+towers.hcalBarrelCells.Path = "emptyCaloCells"
+towers.hcalExtBarrelCells.Path = "emptyCaloCells"
 towers.hcalEndcapCells.Path = "HCalEndcapCells"
 towers.hcalFwdCells.Path = "HCalFwdCells"
 
@@ -208,6 +218,7 @@ audsvc.Auditors = [chra]
 out.AuditExecute = True
 
 list_of_algorithms = [podioinput,
+                      createemptycells,
                       createclusters]
 if noise:
     list_of_algorithms += [createEcalBarrelCells, createclustersNoise]

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -12,7 +12,7 @@ simparser.add_argument("--mu", type=int, help="Number of pileup-events", default
 simparser.add_argument('--sigma1', type=int, default=4, help='Energy threshold [in number of sigmas] for seeding')
 simparser.add_argument('--sigma2', type=int, default=2, help='Energy threshold [in number of sigmas] for neighbours')
 simparser.add_argument('--sigma3', type=int, default=0, help='Energy threshold [in number of sigmas] for last neighbours')
-
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
 simargs, _ = simparser.parse_known_args()
 
 print "=================================="
@@ -27,6 +27,7 @@ puEvents = simargs.mu
 sigma1 = simargs.sigma1
 sigma2 = simargs.sigma2
 sigma3 = simargs.sigma3
+path_to_detector = simargs.detectorPath
 
 print "number of events = ", num_events
 print "input name: ", input_name
@@ -35,13 +36,13 @@ print "electronic noise in Barrel: ", elNoise
 print "pileup noise in Barrel: ", puNoise
 print 'assuming %i pileup events '%(puEvents)
 print 'energy thresholds for reconstruction: ', sigma1, '-', sigma2, '-', sigma3
+print "detectors are taken from: ", path_to_detector
 
 from Gaudi.Configuration import *
 ##############################################################################################################
 #######                                         GEOMETRY                                         #############
 ##############################################################################################################
 
-path_to_detector = '/afs/cern.ch/work/c/cneubuse/public/TopoClusters/FCCSW/'
 detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                   path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
                   path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml']

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -20,7 +20,7 @@ print "==      GENERAL SETTINGS       ==="
 print "=================================="
 num_events = simargs.numEvents
 input_name = simargs.inName
-output_name = 'clusters.root'
+output_name = simargs.outName
 elNoise = simargs.addElectronicsNoise
 puNoise = simargs.addPileupNoise
 puEvents = simargs.mu

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -9,6 +9,9 @@ simparser.add_argument("--physics", action='store_true', help="Physics events")
 simparser.add_argument("--addElectronicsNoise", action='store_true', help="Add electronics noise (default: false)")
 simparser.add_argument("--addPileupNoise", action='store_true', help="Add pileup noise")
 simparser.add_argument("--mu", type=int, help="Number of pileup-events", default=0)
+simparser.add_argument('--sigma1', type=int, default=4, help='Energy threshold [in number of sigmas] for seeding')
+simparser.add_argument('--sigma2', type=int, default=2, help='Energy threshold [in number of sigmas] for neighbours')
+simparser.add_argument('--sigma3', type=int, default=0, help='Energy threshold [in number of sigmas] for last neighbours')
 
 simargs, _ = simparser.parse_known_args()
 
@@ -21,6 +24,9 @@ output_name = 'clusters.root'
 elNoise = simargs.addElectronicsNoise
 puNoise = simargs.addPileupNoise
 puEvents = simargs.mu
+sigma1 = simargs.sigma1
+sigma2 = simargs.sigma2
+sigma3 = simargs.sigma3
 
 print "number of events = ", num_events
 print "input name: ", input_name
@@ -28,6 +34,7 @@ print "output name: ", output_name
 print "electronic noise in Barrel: ", elNoise
 print "pileup noise in Barrel: ", puNoise
 print 'assuming %i pileup events '%(puEvents)
+print 'energy thresholds for reconstruction: ', sigma1, '-', sigma2, '-', sigma3
 
 from Gaudi.Configuration import *
 ##############################################################################################################
@@ -232,9 +239,9 @@ if elNoise:
                                               # cell positions tools for all sub-systems
                                               positionsECalBarrelTool = ECalBcells,
                                               positionsHCalBarrelTool = HCalBcellVols,
-                                              seedSigma = 4,
-                                              neighbourSigma = 2,
-                                              lastNeighbourSigma = 0,
+                                              seedSigma = sigma1,
+                                              neighbourSigma = sigma2,
+                                              lastNeighbourSigma = sigma3,
                                               OutputLevel = INFO)
     createTopoClustersNoise.clusters.Path = "caloClustersBarrelNoise"
     createTopoClustersNoise.clusterCells.Path = "caloClusterBarrelNoiseCells"
@@ -347,9 +354,9 @@ if puNoise:
                                               # cell positions tools for all sub-systems
                                               positionsECalBarrelTool = ECalBcells,
                                               positionsHCalBarrelTool = HCalBcellVols,
-                                              seedSigma = 4,
-                                              neighbourSigma = 2,
-                                              lastNeighbourSigma = 0,
+                                              seedSigma = sigma1,
+                                              neighbourSigma = sigma2,
+                                              lastNeighbourSigma = sigma3,
                                               OutputLevel = DEBUG)
     createTopoClustersNoise.clusters.Path = "caloClustersBarrelNoise"
     createTopoClustersNoise.clusterCells.Path = "caloClusterBarrelNoiseCells"
@@ -405,9 +412,9 @@ createTopoClusters = CaloTopoCluster("CreateTopoClusters",
                                      # cell positions tools for all sub-systems
                                      positionsECalBarrelTool = ECalBcells,
                                      positionsHCalBarrelTool = HCalBcellVols,
-                                     seedSigma = 4,
-                                     neighbourSigma = 0,
-                                     lastNeighbourSigma = 0,
+                                     seedSigma = sigma1,
+                                     neighbourSigma = sigma2,
+                                     lastNeighbourSigma = sigma3,
                                      OutputLevel = INFO)
 createTopoClusters.clusters.Path = "caloClustersBarrel"
 createTopoClusters.clusterCells.Path = "caloClusterBarrelCells"

--- a/inits/pileup.py
+++ b/inits/pileup.py
@@ -1,0 +1,2 @@
+path_to_INIT = '/afs/cern.ch/user/a/azaborow/public/FCCSW_2018/init.sh'
+path_to_FCCSW = '/afs/cern.ch/user/a/azaborow/public/FCCSW_2018/'

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -7,12 +7,6 @@ from ROOT import gSystem
 gSystem.Load("libCaloAnalysis")
 from ROOT import Decoder
 
-import argparse
-parser = argparse.ArgumentParser()
-parser.add_argument("--tracker", action='store_true', help="Convert also tracker hits")
-args, _ = parser.parse_known_args()
-convertTracker = args.tracker
-
 system_decoder = Decoder("system:4")
 ecalBarrel_decoder = Decoder("system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10")
 hcalBarrel_decoder = Decoder("system:4,module:8,row:9,layer:5")
@@ -303,12 +297,12 @@ for event in intree:
             E += c.core.energy
             numHits += 1
 
-        if convertTracker:
+        if event.GetBranchStatus("TrackerPositionedHits"):
             for c in event.TrackerPositionedHits:
                 trackerBarrel_decoder.setValue(c.core.cellId)
                 trackerEndcap_decoder.setValue(c.core.cellId)
                 position = r.TVector3(c.position.x,c.position.y,c.position.z)
-              rec_ene.push_back(c.core.energy)
+                rec_ene.push_back(c.core.energy)
                 rec_eta.push_back(position.Eta())
                 rec_phi.push_back(position.Phi())
                 rec_pt.push_back(c.core.energy*position.Unit().Perp())

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -178,6 +178,28 @@ for event in intree:
             cluster_y.push_back(c.core.position.y/10.)
             cluster_z.push_back(c.core.position.z/10.)
 
+    elif event.GetBranchStatus("caloClusters"):
+        for c in event.caloClusters:
+            position = r.TVector3(c.core.position.x,c.core.position.y,c.core.position.z)
+            cluster_ene.push_back(c.core.energy)
+            cluster_eta.push_back(position.Eta())
+            cluster_phi.push_back(position.Phi())
+            cluster_pt.push_back(c.core.energy*position.Unit().Perp())
+            cluster_x.push_back(c.core.position.x/10.)
+            cluster_y.push_back(c.core.position.y/10.)
+            cluster_z.push_back(c.core.position.z/10.)
+
+    elif event.GetBranchStatus("caloClustersNoise"):
+        for c in event.caloClustersNoise:
+            position = r.TVector3(c.core.position.x,c.core.position.y,c.core.position.z)
+            cluster_ene.push_back(c.core.energy)
+            cluster_eta.push_back(position.Eta())
+            cluster_phi.push_back(position.Phi())
+            cluster_pt.push_back(c.core.energy*position.Unit().Perp())
+            cluster_x.push_back(c.core.position.x/10.)
+            cluster_y.push_back(c.core.position.y/10.)
+            cluster_z.push_back(c.core.position.z/10.)
+
     else:
         for c in event.HCalBarrelCellPositions:
             hcalBarrel_decoder.setValue(c.core.cellId)

--- a/python/send.py
+++ b/python/send.py
@@ -107,11 +107,11 @@ def getJobInfo(argv):
         default_options = 'config/recTopoClusters.py'
         job_type = "ntup/topoClusters"
         if '--noise' in argv:
-            job_type = "ntup/topoClusters/electronicsNoise"
+            job_type = "reco/topoClusters/electronicsNoise"
         elif '--addPileupNoise' in argv:
-            job_type = "ntup/topoClusters/pileupNoise/"
+            job_type = "reco/topoClusters/pileupNoise/"
         else:
-            job_type = "ntup/topoClusters/noNoise"
+            job_type = "reco/topoClusters/noNoise"
         short_job_type = 'recTopo'
         return default_options,job_type,short_job_type,False
 
@@ -531,13 +531,13 @@ if __name__=="__main__":
         if args.recPositions:
             frun.write('python %s/python/Convert.py edm.root $JOBDIR/%s\n'%(current_dir,outfile))
             frun.write('rm edm.root \n')
-        elif '--recTopoClusters' in sys.argv:
-            frun.write('python %s/python/Convert.py $JOBDIR/clusters.root $JOBDIR/%s\n'%(current_dir,outfile))
+        elif '--recTopoClusters' in sys.argv or '--recSlidingWindow' in sys.argv:
+            frun.write('python %s/python/Convert.py $JOBDIR/%s $JOBDIR/clusters.root\n'%(current_dir,outfile))
             frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))
-            reco_path = outdir.replace('/ntup/', '/reco/')
+            reco_path = outdir.replace('/reco', '/ntup')
             if not ut.dir_exist(reco_path):
                 os.system("mkdir -p %s"%(reco_path))
-            frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s\n'%(reco_path+'/'+outfile))
+            frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(outdir, outfile))
 
         if not args.no_eoscopy:
           frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))

--- a/python/send.py
+++ b/python/send.py
@@ -258,7 +258,7 @@ if __name__=="__main__":
 
     ## Use Pileup valid only in certain cases!
     if args.addPileupNoise: # pileup is used to specify level of the pileup noise
-        job_type = job_type.replace("pileupNoise/", "pileupNoise/PU"+str(args.pileup))
+        job_type = job_type.replace("pileupNoise", "pileupNoise/PU"+str(args.pileup))
         short_job_type += "PU"+str(args.pileup)
         num_events = args.numEvents
     elif args.mergePileup: # merge cells from simulated events
@@ -531,13 +531,13 @@ if __name__=="__main__":
         if args.recPositions:
             frun.write('python %s/python/Convert.py edm.root $JOBDIR/%s\n'%(current_dir,outfile))
             frun.write('rm edm.root \n')
-        elif '--recTopoClusters' in sys.argv or '--recSlidingWindow' in sys.argv:
+        elif args.recTopoClusters or args.recSlidingWindow:
             frun.write('python %s/python/Convert.py $JOBDIR/%s $JOBDIR/clusters.root\n'%(current_dir,outfile))
             ntup_path = outdir.replace('/reco', '/ntup')
             if not ut.dir_exist(ntup_path):
                 os.system("mkdir -p %s"%(ntup_path))
             frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(ntup_path, outfile))
-            if '--recSlidingWindow' in sys.argv:
+            if args.recSlidingWindow:
                 analysis_path = outdir.replace('/reco', '/ana')
                 if not ut.dir_exist(analysis_path):
                     os.system("mkdir -p %s"%(analysis_path))

--- a/python/send.py
+++ b/python/send.py
@@ -22,6 +22,18 @@ import makeyaml as my
 import users as us
 
 #__________________________________________________________
+def warning(msg, ifConfirm = False):
+    print "=================================="
+    print "==           WARNING           ==="
+    print "=================================="
+    print msg
+    print "=================================="
+    if ifConfirm:
+        choice = raw_input("Do you want to exit and adjust arguments? [y/n] ")
+        if choice.lower() == 'y':
+            exit()
+
+#__________________________________________________________
 def getInputFiles(path):
     files = []
     All_files = glob.glob("%s/merge.yaml"%path)
@@ -236,7 +248,7 @@ if __name__=="__main__":
         short_job_type = "pileup"+str(args.pileup)
         num_events = args.numEvents
     elif args.recPositions and args.pileup:
-        job_type = "ntup_PU"+str(args.pileup)+"/positions"
+        job_type = "ntupPU"+str(args.pileup)+"/positions"
         short_job_type = "recPos"+str(args.pileup)
     elif args.pileup:
         job_type += "PU"+str(args.pileup)
@@ -306,6 +318,15 @@ if __name__=="__main__":
     rundir = os.getcwd()
     nbjobsSub=0
 
+    if args.mergePileup and not args.local == "inits/pileup.py":
+        warning("Please note that '--mergePileup' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/pileup.py')", True)
+    if args.estimatePileup and not args.local == "inits/pileup.py":
+        warning("Please note that '--preparePileup' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/pileup.py')", True)
+    if args.recPositions and not args.local == "inits/reco.py":
+        warning("Please note that '--recPositions' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/reco.py')", True)
+    if args.recTopoClusters and not args.local == "inits/reco.py":
+        warning("Please note that '--recTopoClusters' is not supported for FCCSW v0.9.1. Make sure that you use suitable software version (recommended: '--local inits/reco.py')", True)
+
     # first make sure the output path for root files exists
     outdir = os.path.join( output_path, version, job_dir, job_type)
     print "Output will be stored in ... ", outdir
@@ -320,12 +341,11 @@ if __name__=="__main__":
         input_files, instatus = takeOnlyNonexistingFiles(input_files, outputID)
 
         if instatus == 0:
-            print "WARNING Directory contains no files"
+            warning("Directory contains no files")
             exit()
         if instatus < num_jobs:
             num_jobs = instatus
-            print "WARNING Directory contains only ", instatus, " files, using all for the reconstruction"
-        print "Input files for reconstruction:"
+            warning("Directory contains only ", instatus, " files, using all for the reconstruction")
     if args.mergePileup:
         # merging pileup events will be done randomly from a given event pool
         all_inputs = ""

--- a/python/send.py
+++ b/python/send.py
@@ -254,11 +254,8 @@ if __name__=="__main__":
         job_type = "simuPU"+str(args.pileup)
         short_job_type += "PU"+str(args.pileup)
         num_events = args.numEvents
-    elif (args.recPositions or args.recTopoClusters) and args.pileup: # if reconstruction is run on pileup (mixed) events
-        job_type = job_type.replace("ntup", "ntupPU"+str(args.pileup))
-        short_job_type += "PU"+str(args.pileup)
-    elif args.recSlidingWindow and args.pileup: # if reconstruction is run on pileup events
-        job_type = job_type.replace("reco", "recoPU"+str(args.pileup))
+    elif (args.recPositions or args.recTopoClusters or args.recSlidingWindow) and args.pileup: # if reconstruction is run on pileup (mixed) events
+        job_type = job_type.replace("ntup", "ntupPU"+str(args.pileup)).replace("reco", "recoPU"+str(args.pileup))
         short_job_type += "PU"+str(args.pileup)
     else:
         warning("'--pileup "+str(args.pileup)+"' is specified but no usecase was found. Please remove it or update job sending script.")

--- a/python/send.py
+++ b/python/send.py
@@ -533,11 +533,10 @@ if __name__=="__main__":
             frun.write('rm edm.root \n')
         elif '--recTopoClusters' in sys.argv or '--recSlidingWindow' in sys.argv:
             frun.write('python %s/python/Convert.py $JOBDIR/%s $JOBDIR/clusters.root\n'%(current_dir,outfile))
-            frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))
-            reco_path = outdir.replace('/reco', '/ntup')
-            if not ut.dir_exist(reco_path):
-                os.system("mkdir -p %s"%(reco_path))
-            frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(outdir, outfile))
+            ntup_path = outdir.replace('/reco', '/ntup')
+            if not ut.dir_exist(ntup_path):
+                os.system("mkdir -p %s"%(ntup_path))
+            frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(ntup_path, outfile))
 
         if not args.no_eoscopy:
           frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))

--- a/python/send.py
+++ b/python/send.py
@@ -270,7 +270,7 @@ if __name__=="__main__":
         short_job_type += "PU"+str(args.pileup)
     elif args.pileup:
         warning("'--pileup "+str(args.pileup)+"' is specified but no usecase was found. Please remove it or update job sending script.")
-    elif args.recSlidingWindow:
+    if args.recSlidingWindow:
         job_type += '/eta' + str(args.winEta) + 'phi' + str(args.winPhi) + 'en' + str(args.enThreshold) + '/'
         short_job_type += '_eta' + str(args.winEta) + 'phi' + str(args.winPhi) + 'en' + str(args.enThreshold)
     elif args.recTopoClusters:
@@ -537,6 +537,11 @@ if __name__=="__main__":
             if not ut.dir_exist(ntup_path):
                 os.system("mkdir -p %s"%(ntup_path))
             frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(ntup_path, outfile))
+            if '--recSlidingWindow' in sys.argv:
+                analysis_path = outdir.replace('/reco', '/ana')
+                if not ut.dir_exist(analysis_path):
+                    os.system("mkdir -p %s"%(analysis_path))
+                frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/hist_%s %s\n'%(outfile, analysis_path))
 
         if not args.no_eoscopy:
           frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))


### PR DESCRIPTION
- adding event merging+mixing to create pileup events (can be also extended in send.py so that signal event is additionally added)
- adding tool to estimate the pileup noise in ecal clusters
- print warnings if wrong config is used (some options may require code newer than the release)
- use path to the detector from the actual local installation if it is specified
- adding new calib constants for the future generation of sim