### PR TITLE
WIP:Digi track hits pile up merger

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,16 @@ This is something that can not be done centrally yet as I do not have rights to 
 
 Expert mode
 ===========
+check eos for a given process
+```
+python python/run.py --checkeos --version v03 --process physics/MinBias/bFieldOn/etaFull/simu
+```
+
+check eos for everything
+```
+python python/run.py --checkeos --version v03
+```
+
 check for a given process
 ```
 python python/run.py --check --version v03 --process physics/MinBias/bFieldOn/etaFull/simu

--- a/README.md
+++ b/README.md
@@ -119,9 +119,11 @@ There are several approaches of addressing the pile-up in the detector:
 2. Mix already simulated events in order to overlay:
 
 
-2.1. merge MinBias events (**--mergePileup**)
+2.1. cells that are later passed to the reconstruction
 
-2.2. merge signal and PU events that are later passed to the reconstruction (**--addPileupToSignal**)
+2.1.1 merge MinBias events (**--mergePileup**)
+
+2.1.2 merge signal and PU events that are later passed to the reconstruction (**--addPileupToSignal**)
 ```
 python python/send.py --singlePart --particle -211 -e 10 --addPileupToSignal --pileup 200 --local inits/pileup.py -N 1 --lsf
 ```

--- a/README.md
+++ b/README.md
@@ -114,14 +114,17 @@ There are several approaches of addressing the pile-up in the detector:
   It creates histograms filling in the information on the deposits per event. This can be later scaled with *sqrt(mu)* for the noise (RMS of the energy distributions) and with *mu* for the mean energy deposit.
   Detailed analysis and this scaling is done with FCC_calo_analysis_cpp toolkit.
 
-- apply estimated noise levels at the cluster level for sliding window reconstruction or layer by layer for the topological clusters (**--addPileupNoise**).
+- apply estimated noise levels at the cluster level for sliding window reconstruction or per cell for the topological clusters (**--addPileupNoise**).
 
 2. Mix already simulated events in order to overlay:
 
-- cells that are later passed to the reconstruction (**--mergePileup**)
 
-- or clusters that can be directly analysed (not yet supported)
+2.1. merge MinBias events (**--mergePileup**)
 
+2.2. merge signal and PU events that are later passed to the reconstruction (**--addPileupToSignal**)
+```
+python python/send.py --singlePart --particle -211 -e 10 --addPileupToSignal --pileup 200 --local inits/pileup.py -N 1 --lsf
+```
 
 Miscellaneous
 ==============
@@ -181,6 +184,7 @@ Official installation of FCCSW does not support certain options (not yet in the 
 
 ```
 --mergePileup --local inits/pileup.py
+--addPileupToSignal --local inits/pileup.py
 --estimatePileup --local inits/pileup.py
 --recPositions --local inits/reco.py
 --recTopoClusters --local inits/reco.py

--- a/config/geantSim_tracker.py
+++ b/config/geantSim_tracker.py
@@ -1,0 +1,210 @@
+
+from GaudiKernel import SystemOfUnits as units
+import argparse
+simparser = argparse.ArgumentParser()
+simparser.add_argument("--bFieldOff", action='store_true', help="Switch OFF magnetic field (default: B field ON)")
+
+simparser.add_argument('-s','--seed', type=int, help='Seed for the random number generator', required=True)
+simparser.add_argument('-N','--numEvents', type=int, help='Number of simulation events to run', required=True)
+simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
+simparser.add_argument('--trackerMergedHits', action="store_true", help='In case hits should be merged')
+simparser.add_argument('--tripletTracker', action="store_true", help="Use the triplet trigger tracker instead of the BaseLine")
+
+
+genTypeGroup = simparser.add_mutually_exclusive_group(required = True) # Type of events to generate
+genTypeGroup.add_argument("--singlePart", action='store_true', help="Single particle events")
+genTypeGroup.add_argument("--pythia", action='store_true', help="Events generated with Pythia")
+genTypeGroup.add_argument("--useVertexSmearTool", action='store_true', help="Use the Gaudi Vertex Smearing Tool")
+
+from math import pi
+singlePartGroup = simparser.add_argument_group('Single particles')
+import sys
+singlePartGroup.add_argument('-e','--energy', type=int, required='--singlePart' in sys.argv, help='Energy of particle in GeV')
+singlePartGroup.add_argument('--etaMin', type=float, default=0., help='Minimal pseudorapidity')
+singlePartGroup.add_argument('--etaMax', type=float, default=0., help='Maximal pseudorapidity')
+singlePartGroup.add_argument('--phiMin', type=float, default=0, help='Minimal azimuthal angle')
+singlePartGroup.add_argument('--phiMax', type=float, default=2*pi, help='Maximal azimuthal angle')
+singlePartGroup.add_argument('--particle', type=int, required='--singlePart' in sys.argv, help='Particle type (PDG)')
+
+pythiaGroup = simparser.add_argument_group('Pythia','Common for min bias and LHE')
+pythiaGroup.add_argument('-c', '--card', type=str, default='Generation/data/Pythia_minbias_pp_100TeV.cmd', help='Path to Pythia card (default: PythiaCards/default.cmd)')
+
+simargs, _ = simparser.parse_known_args()
+
+print "=================================="
+print "==      GENERAL SETTINGS       ==="
+print "=================================="
+magnetic_field = not simargs.bFieldOff
+num_events = simargs.numEvents
+seed = simargs.seed
+output_name = simargs.outName
+path_to_detector = simargs.detectorPath
+print "B field: ", magnetic_field
+print "number of events = ", num_events
+print "seed: ", seed
+print "output name: ", output_name
+print "detectors are taken from: ", path_to_detector
+if simargs.singlePart:
+    energy = simargs.energy
+    etaMin = simargs.etaMin
+    etaMax = simargs.etaMax
+    phiMin = simargs.phiMin
+    phiMax = simargs.phiMax
+    pdg = simargs.particle
+    particle_geant_names = {11: 'e-', -11: 'e+', -13: 'mu+', 13: 'mu-', 22: 'gamma', 111: 'pi0', 211: 'pi+', -211: 'pi-', 130: 'kaon0L'}
+    print "=================================="
+    print "==       SINGLE PARTICLES      ==="
+    print "=================================="
+    print "particle PDG, name: ", pdg, " ", particle_geant_names[pdg]
+    print "energy: ", energy, "GeV"
+    if etaMin == etaMax:
+        print "eta: ", etaMin
+    else:
+        print "eta: from ", etaMin, " to ", etaMax
+    if phiMin == phiMax:
+        print "phi: ", phiMin
+    else:
+        print "phi: from ", phiMin, " to ", phiMax
+elif simargs.pythia:
+    card = simargs.card
+    print "=================================="
+    print "==            PYTHIA           ==="
+    print "=================================="
+    print "card = ", card
+print "=================================="
+
+
+from Gaudi.Configuration import *
+from GaudiKernel import SystemOfUnits as units
+##############################################################################################################
+#######                                         GEOMETRY                                         #############
+##############################################################################################################
+
+path_to_detector=simargs.detectorPath
+
+if simargs.trackerMergedHits:
+   path_to_detector = "/afs/cern.ch/user/j/jhrdinka/public/FCCSW"
+
+if simargs.tripletTracker:
+  detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                    path_to_detector+'/Detector/DetFCChhTrackerTkLayout/triplet/FCCtriplet_1barrel30mm.xml',
+                    ]
+else:
+  detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                    path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
+                    ]
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
+
+##############################################################################################################
+#######                                        SIMULATION                                        #############
+##############################################################################################################
+# Setting random seed, will be propagated to Geant
+from Configurables import  RndmGenSvc
+from GaudiSvc.GaudiSvcConf import HepRndm__Engine_CLHEP__RanluxEngine_
+randomEngine = eval('HepRndm__Engine_CLHEP__RanluxEngine_')
+randomEngine = randomEngine('RndmGenSvc.Engine')
+randomEngine.Seeds = [seed]
+
+from Configurables import SimG4FullSimActions
+actions = SimG4FullSimActions()
+actions.enableHistory=True
+
+# Magnetic field
+from Configurables import SimG4ConstantMagneticFieldTool
+if magnetic_field:
+    field = SimG4ConstantMagneticFieldTool("bField", FieldOn=True, FieldZMax=20*units.m, IntegratorStepper="ClassicalRK4")
+else:
+    field = SimG4ConstantMagneticFieldTool("bField", FieldOn=False)
+
+from Configurables import SimG4Svc
+geantservice = SimG4Svc("SimG4Svc", detector='SimG4DD4hepDetector', physicslist="SimG4FtfpBert", actions=actions, magneticField=field, OutputLevel = VERBOSE)
+# range cut
+geantservice.g4PostInitCommands += ["/run/setCut 0.1 mm"]
+
+from Configurables import SimG4Alg, SimG4SingleParticleGeneratorTool, SimG4SaveTrackerHits, SimG4SaveParticleHistory
+
+savehisttool = SimG4SaveParticleHistory("saveHistory")
+savehisttool.mcParticles.Path = "SimParticles"
+savehisttool.genVertices.Path = "SimVertices"
+
+savetrackertool = SimG4SaveTrackerHits("saveTrackerHits", readoutNames = ["TrackerBarrelReadout", "TrackerEndcapReadout"]) 
+savetrackertool.positionedTrackHits.Path = "TrackerPositionedHits"
+savetrackertool.trackHits.Path = "TrackerHits"
+savetrackertool.digiTrackHits.Path = "TrackerDigiPostPoint"
+outputHitsTools = []
+outputHitsTools += [ "SimG4SaveTrackerHits/saveTrackerHits"]
+outputHitsTools += [ "SimG4SaveParticleHistory/saveHistory"]
+
+geantsim = SimG4Alg("SimG4Alg", outputs = outputHitsTools)
+
+if simargs.singlePart:
+    from Configurables import SimG4SingleParticleGeneratorTool
+    pgun=SimG4SingleParticleGeneratorTool("SimG4SingleParticleGeneratorTool", saveEdm=True,
+                                          particleName=particle_geant_names[pdg], energyMin=energy * 1000, energyMax=energy * 1000,
+                                          etaMin=etaMin, etaMax=etaMax, phiMin = phiMin, phiMax = phiMax, OutputLevel = VERBOSE)
+    geantsim.eventProvider = pgun
+else:
+    from Configurables import PythiaInterface, GenAlg, GaussSmearVertex
+    smeartool = GaussSmearVertex("GaussSmearVertex")
+    if simargs.useVertexSmearTool:
+        smeartool.xVertexSigma = 0.5*units.mm
+        smeartool.yVertexSigma = 0.5*units.mm
+        smeartool.zVertexSigma = 40*units.mm
+        smeartool.tVertexSigma = 180*units.picosecond
+
+    pythia8gentool = PythiaInterface("Pythia8",Filename=card)
+    pythia8gen = GenAlg("Pythia8", SignalProvider=pythia8gentool, VertexSmearingTool=smeartool)
+    pythia8gen.hepmc.Path = "hepmc"
+    from Configurables import HepMCToEDMConverter
+    hepmc_converter = HepMCToEDMConverter("Converter", hepmcStatusList=[]) # save all the particles from Pythia
+    hepmc_converter.hepmc.Path="hepmc"
+    hepmc_converter.genparticles.Path="allGenParticles"
+    hepmc_converter.genvertices.Path="GenVertices"
+    from Configurables import GenParticleFilter
+    ### Filters generated particles
+    # accept is a list of particle statuses that should be accepted
+    genfilter = GenParticleFilter("StableParticles", accept=[1], OutputLevel=DEBUG)
+    genfilter.allGenParticles.Path = "allGenParticles"
+    genfilter.filteredGenParticles.Path = "GenParticles"
+    from Configurables import SimG4PrimariesFromEdmTool
+    particle_converter = SimG4PrimariesFromEdmTool("EdmConverter")
+    particle_converter.genParticles.Path = "GenParticles"
+    geantsim.eventProvider = particle_converter
+
+# PODIO algorithm
+from Configurables import ApplicationMgr, FCCDataSvc, PodioOutput
+podioevent = FCCDataSvc("EventDataSvc")
+out = PodioOutput("out")
+out.outputCommands = ["drop *",
+                      "keep GenParticles",
+                      "keep GenVertices",
+                      "keep SimParticles",
+                      "keep SimVertices",
+                      "keep TrackerHits",
+                      "keep TrackerPositionedHits",
+                      "keep TrackerDigiPostPoint",
+                      ]
+out.filename = output_name
+
+#CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+geantsim.AuditExecute = True
+out.AuditExecute = True
+
+
+list_of_algorithms = [geantsim,  out]
+if simargs.pythia:
+    list_of_algorithms = [pythia8gen, hepmc_converter, genfilter] + list_of_algorithms
+
+ApplicationMgr(
+    TopAlg = list_of_algorithms,
+    EvtSel = 'NONE',
+    EvtMax   = num_events,
+    ExtSvc = [podioevent, geoservice, geantservice],
+)

--- a/config/overlayPileupWithSignal.py
+++ b/config/overlayPileupWithSignal.py
@@ -4,7 +4,7 @@ simparser = argparse.ArgumentParser()
 simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
 simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
 simparser.add_argument('-N','--numEvents',  type=int, help='Number of simulation events to run', required=True)
-simparser.add_argument("--mu", type=int, help="Number of pileup-events", default=0)
+simparser.add_argument("--pileup", type=int, help="Number of pileup-events", default=0)
 simparser.add_argument('--inPileupFileNames',type=str, nargs = "+", help='Name of the pileup input file',required=True)
 
 simargs, _ = simparser.parse_known_args()
@@ -15,7 +15,7 @@ print "=================================="
 num_events = simargs.numEvents
 input_name = simargs.inName
 output_name = simargs.outName
-puEvents = simargs.mu
+puEvents = simargs.pileup
 
 print "number of events = ", num_events
 print "input name: ", input_name
@@ -23,7 +23,7 @@ print "output name: ", output_name
 
 input_pileup_name = []
 input_pileup_name = simargs.inPileupFileNames
-print 'aadd %i pileup events '%(puEvents)
+print 'add %i pileup events '%(puEvents)
 print "Pileup input file names: ", input_pileup_name
 
 pileupFilenames = input_pileup_name

--- a/config/overlayPileupWithSignal.py
+++ b/config/overlayPileupWithSignal.py
@@ -1,0 +1,224 @@
+import argparse, os
+simparser = argparse.ArgumentParser()
+
+simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
+simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('-N','--numEvents',  type=int, help='Number of simulation events to run', required=True)
+simparser.add_argument("--mu", type=int, help="Number of pileup-events", default=0)
+simparser.add_argument('--inPileupFileNames',type=str, nargs = "+", help='Name of the pileup input file',required=True)
+
+simargs, _ = simparser.parse_known_args()
+
+print "=================================="
+print "==      GENERAL SETTINGS       ==="
+print "=================================="
+num_events = simargs.numEvents
+input_name = simargs.inName
+output_name = simargs.outName
+puEvents = simargs.mu
+
+print "number of events = ", num_events
+print "input name: ", input_name
+print "output name: ", output_name
+
+input_pileup_name = []
+input_pileup_name = simargs.inPileupFileNames
+print 'aadd %i pileup events '%(puEvents)
+print "Pileup input file names: ", input_pileup_name
+
+pileupFilenames = input_pileup_name
+import random
+random.shuffle(pileupFilenames)
+
+from Gaudi.Configuration import *
+
+# Names of cells collections
+ecalBarrelCellsName = "ECalBarrelCells"
+ecalEndcapCellsName = "ECalEndcapCells"
+ecalFwdCellsName = "ECalFwdCells"
+hcalBarrelCellsName = "HCalBarrelCells"
+hcalExtBarrelCellsName = "HCalExtBarrelCells"
+hcalEndcapCellsName = "HCalEndcapCells"
+hcalFwdCellsName = "HCalFwdCells"
+# Readouts
+ecalBarrelReadoutName = "ECalBarrelPhiEta"
+ecalEndcapReadoutName = "EMECPhiEta"
+ecalFwdReadoutName = "EMFwdPhiEta"
+hcalBarrelReadoutName = "HCalBarrelReadout"
+hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
+hcalEndcapReadoutName = "HECPhiEta"
+hcalFwdReadoutName = "HFwdPhiEta"
+tailCatcherReadoutName = "Muons_Readout"
+
+##############################################################################################################
+#######                                        INPUT                                             #############
+##############################################################################################################
+
+# reads HepMC text file and write the HepMC::GenEvent to the data service
+from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
+podioevent = FCCDataSvc("EventDataSvc", input=input_name)
+
+podioinput = PodioInput("PodioReader", collections = ["GenParticles", "GenVertices",
+                         "ECalBarrelCells", "ECalEndcapCells", "ECalFwdCells",
+                         "HCalBarrelCells", "HCalExtBarrelCells", "HCalEndcapCells", "HCalFwdCells"], OutputLevel = DEBUG)
+
+##############################################################################################################
+#######                                         GEOMETRY                                         #############
+##############################################################################################################
+path_to_detector = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj"
+detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                  path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
+                  path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
+                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
+                  path_to_detector+'/Detector/DetFCChhTailCatcher/compact/FCChh_TailCatcher.xml',
+                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
+                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Shielding.xml']
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
+
+##############################################################################################################
+#######                                       ADD PILEUP EVENTS                              #############
+##############################################################################################################
+
+# edm data from simulation: hits and positioned hits
+from Configurables import PileupCaloHitMergeTool
+ecalbarrelmergetool = PileupCaloHitMergeTool("ECalBarrelHitMerge")
+#ecalbarrelmergetool.noPositionedHits = True
+ecalbarrelmergetool.pileupHitsBranch = "mergedECalBarrelCells"
+ecalbarrelmergetool.signalHits = "ECalBarrelCells"
+ecalbarrelmergetool.mergedHits = "pileupECalBarrelCells"
+
+# edm data from simulation: hits and positioned hits
+ecalendcapmergetool = PileupCaloHitMergeTool("ECalEndcapHitMerge")
+ecalendcapmergetool.pileupHitsBranch = "mergedECalEndcapCells"
+ecalendcapmergetool.signalHits = "ECalEndcapCells"
+ecalendcapmergetool.mergedHits = "pileupECalEndcapCells"
+
+# edm data from simulation: hits and positioned hits
+ecalfwdmergetool = PileupCaloHitMergeTool("ECalFwdHitMerge")
+# branchnames for the pileup
+ecalfwdmergetool.pileupHitsBranch = "mergedECalFwdCells"
+ecalfwdmergetool.signalHits = "ECalFwdCells"
+ecalfwdmergetool.mergedHits = "pileupECalFwdCells"
+
+# edm data from simulation: hits and positioned hits
+hcalbarrelmergetool = PileupCaloHitMergeTool("HCalBarrelHitMerge")
+#hcalbarrelmergetool.noPositionedHits = True
+hcalbarrelmergetool.pileupHitsBranch = "mergedHCalBarrelCells"
+hcalbarrelmergetool.signalHits = "HCalBarrelCells"
+hcalbarrelmergetool.mergedHits = "pileupHCalBarrelCells"
+
+ # edm data from simulation: hits and positioned hits
+hcalextbarrelmergetool = PileupCaloHitMergeTool("HCalExtBarrelHitMerge")
+hcalextbarrelmergetool.pileupHitsBranch = "mergedHCalExtBarrelCells"
+hcalextbarrelmergetool.signalHits = "HCalExtBarrelCells"
+hcalextbarrelmergetool.mergedHits = "pileupHCalExtBarrelCells"
+
+# edm data from simulation: hits and positioned hits
+hcalfwdmergetool = PileupCaloHitMergeTool("HCalFwdHitMerge")
+hcalfwdmergetool.pileupHitsBranch = "mergedHCalFwdCells"
+hcalfwdmergetool.signalHits = "HCalFwdCells"
+hcalfwdmergetool.mergedHits = "pileupHCalFwdCells"
+
+# edm data from simulation: hits and positioned hits
+hcalfwdmergetool = PileupCaloHitMergeTool("HCalEndcapHitMerge")
+hcalfwdmergetool.pileupHitsBranch = "mergedHCalEndcapCells"
+hcalfwdmergetool.signalHits = "HCalEndcapCells"
+hcalfwdmergetool.mergedHits = "pileupHCalEndcapCells"
+
+   
+# use the pileuptool to specify the number of pileup
+from Configurables import ConstPileUp
+pileuptool = ConstPileUp("MyPileupTool", numPileUpEvents=1)
+
+# algorithm for the overlay
+from Configurables import PileupOverlayAlg
+overlay = PileupOverlayAlg()
+overlay.pileupFilenames = pileupFilenames
+overlay.randomizePileup = True
+overlay.mergeTools = [
+                      "PileupCaloHitMergeTool/ECalBarrelHitMerge",
+                      "PileupCaloHitMergeTool/ECalEndcapHitMerge",
+                      "PileupCaloHitMergeTool/ECalFwdHitMerge",
+                      "PileupCaloHitMergeTool/HCalBarrelHitMerge",
+                      "PileupCaloHitMergeTool/HCalExtBarrelHitMerge",
+                      "PileupCaloHitMergeTool/HCalEndcapHitMerge",
+                      "PileupCaloHitMergeTool/HCalFwdHitMerge"
+                      ]
+overlay.PileUpTool = pileuptool
+
+##############################################################################################################
+#######                                       DIGITISATION                                       #############
+##############################################################################################################
+from Configurables import CreateCaloCells
+createEcalBarrelCells = CreateCaloCells("CreateEcalBarrelCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createEcalBarrelCells.hits.Path="pileupECalBarrelCells"
+createEcalBarrelCells.cells.Path="addedPUECalBarrelCells"
+createEcalEndcapCells = CreateCaloCells("CreateEcalEndcapCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createEcalEndcapCells.hits.Path="pileupECalEndcapCells"
+createEcalEndcapCells.cells.Path="addedPUECalEndcapCells"
+createEcalFwdCells = CreateCaloCells("CreateEcalFwdCells",
+                                     doCellCalibration=False,
+                                     addCellNoise=False, filterCellNoise=False)
+createEcalFwdCells.hits.Path="pileupECalFwdCells"
+createEcalFwdCells.cells.Path="addedPUECalFwdCells"
+createHcalBarrelCells = CreateCaloCells("CreateHcalBarrelCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createHcalBarrelCells.hits.Path="pileupHCalBarrelCells"
+createHcalBarrelCells.cells.Path="addedPUHCalBarrelCells"
+createHcalExtBarrelCells = CreateCaloCells("CreateHcalExtBarrelCells",
+                                           doCellCalibration=False,
+                                           addCellNoise=False, filterCellNoise=False)
+createHcalExtBarrelCells.hits.Path="pileupHCalExtBarrelCells"
+createHcalExtBarrelCells.cells.Path="addedPUHCalExtBarrelCells"
+createHcalEndcapCells = CreateCaloCells("CreateHcalEndcapCells",
+                                        doCellCalibration=False,
+                                        addCellNoise=False, filterCellNoise=False)
+createHcalEndcapCells.hits.Path="pileupHCalEndcapCells"
+createHcalEndcapCells.cells.Path="addedPUHCalEndcapCells"
+createHcalFwdCells = CreateCaloCells("CreateHcalFwdCells",
+                                     doCellCalibration=False,
+                                     addCellNoise=False, filterCellNoise=False)
+createHcalFwdCells.hits.Path="pileupHCalFwdCells"
+createHcalFwdCells.cells.Path="addedPUHCalFwdCells"
+
+# PODIO algorithm
+out = PodioOutput("out", OutputLevel=DEBUG)
+out.outputCommands = ["drop *", "keep GenParticles", "keep GenVertices", "keep addedPUECalBarrelCells", "keep addedPUECalEndcapCells", "keep addedPUECalFwdCells", "keep addedPUHCalBarrelCells", "keep addedPUHCalExtBarrelCells", "keep addedPUHCalEndcapCells", "keep addedPUHCalFwdCells"]
+out.filename = output_name
+
+#CPU information
+from Configurables import AuditorSvc, ChronoAuditor
+chra = ChronoAuditor()
+audsvc = AuditorSvc()
+audsvc.Auditors = [chra]
+podioinput.AuditExecute = True
+out.AuditExecute = True
+
+list_of_algorithms = [podioinput,
+                      overlay,
+                      createEcalBarrelCells,
+                      createEcalEndcapCells,
+                      createEcalFwdCells,
+                      createHcalBarrelCells,
+                      createHcalExtBarrelCells,
+                      createHcalEndcapCells,
+                      createHcalFwdCells]
+   
+list_of_algorithms += [out]
+
+ApplicationMgr(
+    TopAlg = list_of_algorithms,
+    EvtSel = 'NONE',
+    EvtMax   = num_events,
+    ExtSvc = [geoservice, podioevent, audsvc],
+    OutputLevel = INFO)

--- a/config/overlayPileup_tracker.py
+++ b/config/overlayPileup_tracker.py
@@ -1,0 +1,128 @@
+import argparse
+simparser = argparse.ArgumentParser()
+simparser.add_argument('--inName', type=str, nargs = "+", help='Name of the input file', required=True)
+simparser.add_argument('--inSignalName', type=str, help='Name of the input file with signal')
+simparser.add_argument('--outName', type=str, help='Name of the output file', required=True)
+simparser.add_argument('-N','--numEvents', type=int, help='Number of simulation events to run', required=True)
+simparser.add_argument('--pileup', type=int, help='Pileup', default = 1)
+simparser.add_argument('--detectorPath', type=str, help='Path to detectors', default = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj")
+simparser.add_argument('--mergeSimParticles', action='store_true', help='Set this flag to allow simulated particles to be merged as well')
+simargs, _ = simparser.parse_known_args()
+
+print "=================================="
+print "==      GENERAL SETTINGS       ==="
+print "=================================="
+num_events = simargs.numEvents
+path_to_detector = simargs.detectorPath
+print "detectors are taken from: ", path_to_detector
+input_name = simargs.inName
+if simargs.inSignalName:
+    input_signal_name = simargs.inSignalName
+    print "input signal name: ", input_signal_name
+output_name = simargs.outName
+print "input pileup name: ", input_name
+print "output name: ", output_name
+print "=================================="
+
+from Gaudi.Configuration import *
+
+from Configurables import FCCDataSvc
+
+# list of names of files with pileup event data -- to be overlaid
+pileupFilenames = input_name
+# the file containing the signal events
+if simargs.inSignalName:
+    signalFilename = input_signal_name
+    noSignal = False
+    # the collections to be read from the signal event
+    signalCollections = ["TrackerHits","TrackerPositionedHits","TrackerDigiPostPoint","SimParticles"]
+    # Data service
+    podioevent = FCCDataSvc("EventDataSvc", input=signalFilename)
+    # use PodioInput for Signal
+    from Configurables import PodioInput
+    podioinput = PodioInput("PodioReader", collections=signalCollections, OutputLevel=DEBUG)
+    list_of_algorithms = [podioinput]
+else:
+    signalFilename = ""
+    noSignal = True
+    podioevent = FCCDataSvc("EventDataSvc")
+    list_of_algorithms = []
+
+
+
+##############################################################################################################
+#######                                         GEOMETRY                                         #############
+##############################################################################################################
+path_to_detector = "/cvmfs/fcc.cern.ch/sw/releases/0.9.1/x86_64-slc6-gcc62-opt/linux-scientificcernslc6-x86_64/gcc-6.2.0/fccsw-0.9.1-c5dqdyv4gt5smfxxwoluqj2pjrdqvjuj"
+detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
+                  path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml']
+
+from Configurables import GeoSvc
+geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use, OutputLevel = WARNING)
+
+inputPUPositionedHits = "TrackerPositionedHits"
+inputPUDigiTrackHits = "TrackerDigiPostPoint"
+inputPUSimParticles = "SimParticles"
+
+outputPositionedHits = "puTrackerPositionedHits"
+outputDigiTrackHits  = "puTrackerDigiPostPoint"
+outputSimParticles   = "puSimParticles"
+
+if simargs.inSignalName:
+    inputPUPositionedHits = "puTrackerPositionedHits"
+    inputPUDigiTrackHits = "puTrackerDigiPostPoint"
+    inputPUSimParticles = "puSimParticles"
+    
+    outputPositionedHits = "overlaidPositionedTrackHits"
+    outputDigiTrackHits  = "overlaidTrackerDigiPostPoint"
+    outputSimParticles   = "overlaidSimParticles"
+
+# edm data from simulation: hits and positioned hits
+from Configurables import PileupDigiTrackHitMergeTool
+trackhitsmergetool = PileupDigiTrackHitMergeTool("DigiTrackHitsMerger")
+# branchnames for the pileup
+trackhitsmergetool.pileupHitsBranch = inputPUPositionedHits
+trackhitsmergetool.pileupDigiHitsBranch = inputPUDigiTrackHits
+trackhitsmergetool.pileupParticleBranch = inputPUSimParticles
+# branchnames for the signal
+trackhitsmergetool.signalPositionedHits = "TrackerPositionedHits"
+trackhitsmergetool.signalDigiHits = "TrackerDigiPostPoint"
+trackhitsmergetool.signalParticles = "SimParticles"
+# branchnames for the output
+trackhitsmergetool.mergedPositionedHits = outputPositionedHits
+trackhitsmergetool.mergedDigiHits = outputDigiTrackHits
+trackhitsmergetool.mergedParticles = outputSimParticles
+if simargs.mergeSimParticles:
+    trackhitsmergetool.mergeParticles = TRUE
+
+# use the pileuptool to specify the number of pileup
+from Configurables import ConstPileUp
+pileuptool = ConstPileUp("MyPileupTool", numPileUpEvents=simargs.pileup)
+
+# algorithm for the overlay
+from Configurables import PileupOverlayAlg
+overlay = PileupOverlayAlg()
+overlay.pileupFilenames = pileupFilenames
+overlay.randomizePileup =  True
+overlay.doShuffleInputFiles = True
+overlay.mergeTools = ["PileupDigiTrackHitMergeTool/DigiTrackHitsMerger"]
+overlay.PileUpTool = pileuptool
+overlay.noSignal = noSignal
+
+# PODIO algorithm
+from Configurables import PodioOutput
+out = PodioOutput("out")
+out.outputCommands = ["drop *", "keep "+ outputPositionedHits, "keep "+ outputDigiTrackHits, "keep " + outputSimParticles]
+out.filename = output_name
+
+list_of_algorithms += [overlay,
+                       out
+                       ]
+
+# ApplicationMgr
+from Configurables import ApplicationMgr
+ApplicationMgr( TopAlg=list_of_algorithms,
+                EvtSel='NONE',
+                EvtMax=num_events,
+                ExtSvc=[geoservice, podioevent]
+ )

--- a/config/recPositions.py
+++ b/config/recPositions.py
@@ -59,7 +59,7 @@ tailCatcherReadoutName = "Muons_Readout"
 from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
 podioevent = FCCDataSvc("EventDataSvc", input=input_name)
 
-coll_names_read = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", prefix+"HCalExtBarrelCells", prefix+"ECalEndcapCells", prefix+"HCalEndcapCells", prefix+"ECalFwdCells", prefix+"HCalFwdCells"]
+coll_names_read = [prefix+"ECalBarrelCells", prefix+"HCalBarrelCells", prefix+"HCalExtBarrelCells", prefix+"ECalEndcapCells", prefix+"HCalEndcapCells", prefix+"ECalFwdCells", prefix+"HCalFwdCells", prefix+"GenParticles", prefix+"GenVertices"]
 if addMuons:
     coll_names_read += ["TailCatcherCells"]
 podioinput = PodioInput("PodioReader", collections = coll_names_read, OutputLevel = DEBUG)

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -24,12 +24,18 @@ noise = simargs.addElectronicsNoise
 path_to_detector = simargs.detectorPath
 winEta = simargs.winEta
 winPhi = simargs.winPhi
+winEtaSeed = int(math.floor(winEta*2./4.))
+winPhiSeed = int(math.floor(winPhi*2./4.))
 winEtaPos = int(math.floor(winEta*2./4.))
 winPhiPos = int(math.floor(winPhi*2./4.))
 winEtaDup = int(math.floor(winEta*3./4.))
 winPhiDup = int(math.floor(winPhi*2./4.))
 
 ## make sure that window size is odd
+if winEtaSeed %2 == 0:
+    winEtaSeed = winEtaSeed +1
+if winPhiSeed %2 == 0:
+    winPhiSeed = winPhiSeed +1
 if winEtaPos %2 == 0:
     winEtaPos = winEtaPos +1 
 if winPhiPos %2 == 0:
@@ -46,8 +52,8 @@ print "input name: ", input_name
 print "output name: ", output_name
 print "electronic noise in E and HCAL: ", noise
 print "detectors are taken from: ", path_to_detector
-print "cluster eta size: ", winEta
-print "cluster phi size: ", winPhi
+print "seed cluster eta size: ", winEtaSeed
+print "seed cluster phi size: ", winPhiSeed
 print "pos cluster eta size: ", winEtaPos
 print "pos cluster phi size: ", winPhiPos
 print "dup cluster eta size: ", winEtaDup
@@ -235,7 +241,7 @@ if noise:
     towersNoise.hcalFwdCells.Path = "HCalFwdCells"
     createclustersNoise = CreateCaloClustersSlidingWindow("CreateCaloClustersNoise",
                                                           towerTool = towersNoise,
-                                                          nEtaWindow = winEta, nPhiWindow = winPhi,
+                                                          nEtaWindow = winEtaSeed, nPhiWindow = winPhiSeed,
                                                           nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
                                                           nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                           nEtaFinal = winEta, nPhiFinal = winPhi,
@@ -299,7 +305,7 @@ towers.hcalFwdCells.Path = "HCalFwdCells"
 
 createclusters = CreateCaloClustersSlidingWindow("CreateCaloClusters",
                                                  towerTool = towers,
-                                                 nEtaWindow = winEta, nPhiWindow = winPhi,
+                                                 nEtaWindow = winEtaSeed, nPhiWindow = winPhiSeed,
                                                  nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
                                                  nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                  nEtaFinal = winEta, nPhiFinal = winPhi,

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -1,4 +1,4 @@
-import argparse
+import argparse, math
 simparser = argparse.ArgumentParser()
 
 simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
@@ -33,9 +33,9 @@ winPhiDup = int(math.floor(winPhi*2./4.))
 
 ## make sure that window size is odd
 if winEtaSeed %2 == 0:
-    winEtaSeed = winEtaSeed +1
+    winEtaSeed = winEtaSeed +1 
 if winPhiSeed %2 == 0:
-    winPhiSeed = winPhiSeed +1
+    winPhiSeed = winPhiSeed +1 
 if winEtaPos %2 == 0:
     winEtaPos = winEtaPos +1 
 if winPhiPos %2 == 0:
@@ -50,7 +50,7 @@ pileup = simargs.mu
 print "number of events = ", num_events
 print "input name: ", input_name
 print "output name: ", output_name
-print "electronic noise in ECAL: ", noise
+print "electronic noise in E and HCAL: ", noise
 print "detectors are taken from: ", path_to_detector
 print "seed cluster eta size: ", winEtaSeed
 print "seed cluster phi size: ", winPhiSeed
@@ -85,7 +85,7 @@ geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use)
 # ECAL readouts
 ecalBarrelReadoutName = "ECalBarrelEta"
 ecalBarrelReadoutNamePhiEta = "ECalBarrelPhiEta"
-ecalEndcapReadoutName = "EMECPhiEtaReco"
+ecalEndcapReadoutName = "EMECPhiEta"
 ecalFwdReadoutName = "EMFwdPhiEta"
 ecalBarrelNoisePath = "/afs/cern.ch/user/a/azaborow/public/FCCSW/elecNoise_ecalBarrel_50Ohm_traces2_2shieldWidth_noise.root"
 ecalEndcapNoisePath = "/afs/cern.ch/user/n/novaj/public/elecNoise_emec_6layers.root"
@@ -95,9 +95,18 @@ ecalBarrelPileupHistName = "h_pileup_layer"
 ecalEndcapNoiseHistName = "h_elecNoise_fcc_"
 # HCAL readouts
 hcalBarrelReadoutName = "HCalBarrelReadout"
+hcalBarrelPhiEtaReadoutName = "BarHCal_Readout_phieta"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
+hcalExtBarrelPhiEtaReadoutName = "ExtBarHCal_Readout_phieta"
 hcalEndcapReadoutName = "HECPhiEta"
 hcalFwdReadoutName = "HFwdPhiEta"
+# active material identifier name
+hcalIdentifierName = [ "module", "row", "layer" ]
+# active material volume name
+hcalVolumeName = [ "moduleVolume", "wedgeVolume", "layerVolume" ]
+# HCAL bitfield names& values
+hcalFieldNames = ["system"] 
+hcalFieldValues = [8]
 ##############################################################################################################
 #######                                           INPUT                                          #############
 ##############################################################################################################
@@ -109,8 +118,8 @@ podioinput = PodioInput("in", collections = ["GenVertices",
                                              "ECalBarrelCells",
                                              "ECalEndcapCells",
                                              "ECalFwdCells",
-                                             # "HCalBarrelCells",
-                                             # "HCalExtBarrelCells",
+                                             "HCalBarrelCells",
+                                             "HCalExtBarrelCells",
                                              "HCalEndcapCells",
                                              "HCalFwdCells"])
 
@@ -123,7 +132,7 @@ createemptycells.cells.Path = "emptyCaloCells"
 
 from Configurables import CreateCaloCells
 if noise:
-    from Configurables import NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool
+    from Configurables import NoiseCaloCellsFromFileTool, NoiseCaloCellsFlatTool, TubeLayerPhiEtaCaloTool, NestedVolumesCaloTool
 # 1. ECAL BARREL
 if noise:
     noiseBarrel = NoiseCaloCellsFromFileTool("NoiseBarrel",
@@ -149,6 +158,24 @@ if noise:
                                             noiseTool = noiseBarrel,
                                             hits="ECalBarrelCells",
                                             cells="ECalBarrelCellsNoise")
+    # 2. HCAL BARREL
+    noiseHcal = NoiseCaloCellsFlatTool("HCalNoise", cellNoise = 0.009)
+
+    hcalgeo = NestedVolumesCaloTool("HcalGeo",
+                                    activeVolumeName = hcalVolumeName,
+                                    activeFieldName = hcalIdentifierName,
+                                    readoutName = hcalBarrelReadoutName,
+                                    fieldNames = hcalFieldNames,
+                                    fieldValues = hcalFieldValues,
+                                    OutputLevel = INFO)
+    
+    createHcalBarrelCells =CreateCaloCells("CreateHCalBarrelCells", geometryTool = hcalgeo,
+                                           doCellCalibration = False, addCellNoise = True,
+                                           filterCellNoise = False, noiseTool = noiseHcal,
+                                           OutputLevel = INFO) 
+    createHcalBarrelCells.hits.Path ="HCalBarrelCells" 
+    createHcalBarrelCells.cells.Path ="HCalBarrelCellsNoise"
+
     # noiseEndcap = NoiseCaloCellsFromFileTool("NoiseEndcap",
     #                                          readoutName = ecalEndcapReadoutName,
     #                                          noiseFileName = ecalEndcapNoisePath,
@@ -171,7 +198,29 @@ if noise:
     #                                         noiseTool = noiseEndcap,
     #                                         hits="ECalEndcapCells",
     #                                         cells="ECalEndcapCellsNoise")
-    #Create calo clusters
+ 
+
+
+    # additionally for HCal
+    from Configurables import CreateVolumeCaloPositions
+    positionsHcalNoise = CreateVolumeCaloPositions("positionsHcalNoise", OutputLevel = INFO)
+    positionsHcalNoise.hits.Path = "HCalBarrelCellsNoise"
+    positionsHcalNoise.positionedHits.Path = "HCalBarrelPositionsNoise"
+    
+    from Configurables import RedoSegmentation
+    resegmentHcalNoise = RedoSegmentation("ReSegmentationHcalNoise",
+                                          # old bitfield (readout)
+                                          oldReadoutName = hcalBarrelReadoutName,
+                                          # # specify which fields are going to be altered (deleted/rewritten)
+                                          # oldSegmentationIds = ["eta","phi"],
+                                          # new bitfield (readout), with new segmentation
+                                          newReadoutName = hcalBarrelPhiEtaReadoutName,
+                                          debugPrint = 10,
+                                          OutputLevel = INFO,
+                                          inhits = "HCalBarrelPositionsNoise",
+                                          outhits = "newHCalBarrelCellsNoise")
+    
+   #Create calo clusters
     from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
     from GaudiKernel.PhysicalConstants import pi
     towersNoise = CaloTowerTool("towersNoise",
@@ -179,18 +228,14 @@ if noise:
                            ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                            ecalEndcapReadoutName = ecalEndcapReadoutName,
                            ecalFwdReadoutName = ecalFwdReadoutName,
-                           # hcalBarrelReadoutName = hcalBarrelReadoutName,
-                           # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
-                           hcalBarrelReadoutName = "",
-                           hcalExtBarrelReadoutName = "",
+                           hcalBarrelReadoutName = hcalBarrelPhiEtaReadoutName,
+                           hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
                            hcalEndcapReadoutName = hcalEndcapReadoutName,
                            hcalFwdReadoutName = hcalFwdReadoutName)
     towersNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     towersNoise.ecalEndcapCells.Path = "ECalEndcapCells"
     towersNoise.ecalFwdCells.Path = "ECalFwdCells"
-    # towersNoise.hcalBarrelCells.Path = "HCalBarrelCells"
-    # towersNoise.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
-    towersNoise.hcalBarrelCells.Path = "emptyCaloCells"
+    towersNoise.hcalBarrelCells.Path = "newHCalBarrelCellsNoise"
     towersNoise.hcalExtBarrelCells.Path = "emptyCaloCells"
     towersNoise.hcalEndcapCells.Path = "HCalEndcapCells"
     towersNoise.hcalFwdCells.Path = "HCalFwdCells"
@@ -203,19 +248,39 @@ if noise:
                                                           energyThreshold = enThreshold,
                                                           OutputLevel = INFO)
     createclustersNoise.clusters.Path = "caloClustersNoise"
-    from Configurables import CorrectCluster
-    correctClusters = CorrectCluster("CorrectCluster",
-                                     energyAxis = energy,
-                                     numLayers = 8,
-                                     etaValues = [0,0.25],
-                                     presamplerShiftP0 = [0.05938, 0.05938],
-                                     presamplerShiftP1 = [0.0001833,0.0001833],
-                                     presamplerScaleP0  = [2.4, 2.4],
-                                     presamplerScaleP1  = [-0.006838, -0.006838],
-                                     mu = pileup,
-                                     noiseFileName = ecalBarrelPileupNoisePath)
-    correctClusters.clusters.Path = "caloClustersNoise",
-    correctClusters.correctedClusters.Path = "caloClustersCorrected"
+
+# additionally for HCal
+from Configurables import CreateVolumeCaloPositions
+positionsHcal = CreateVolumeCaloPositions("positionsHcal", OutputLevel = INFO)
+positionsHcal.hits.Path = "HCalBarrelCells"
+positionsHcal.positionedHits.Path = "HCalBarrelPositions"
+positionsExtHcal = CreateVolumeCaloPositions("positionsExtHcal", OutputLevel = INFO)
+positionsExtHcal.hits.Path = "HCalExtBarrelCells"
+positionsExtHcal.positionedHits.Path = "HCalExtBarrelPositions"
+
+from Configurables import RedoSegmentation
+resegmentHcal = RedoSegmentation("ReSegmentationHcal",
+                             # old bitfield (readout)
+                             oldReadoutName = hcalBarrelReadoutName,
+                             # # specify which fields are going to be altered (deleted/rewritten)
+                             # oldSegmentationIds = ["eta","phi"],
+                             # new bitfield (readout), with new segmentation
+                             newReadoutName = hcalBarrelPhiEtaReadoutName,
+                             debugPrint = 10,
+                             OutputLevel = INFO,
+                             inhits = "HCalBarrelPositions",
+outhits = "newHCalBarrelCells")
+resegmentExtHcal = RedoSegmentation("ReSegmentationExtHcal",
+                             # old bitfield (readout)
+                             oldReadoutName = hcalExtBarrelReadoutName,
+                             # # specify which fields are going to be altered (deleted/rewritten)
+                             # oldSegmentationIds = ["eta","phi"],
+                             # new bitfield (readout), with new segmentation
+                             newReadoutName = hcalExtBarrelPhiEtaReadoutName,
+                             debugPrint = 10,
+                             OutputLevel = INFO,
+                             inhits = "HCalExtBarrelPositions",
+outhits = "newHCalExtBarrelCells")
 
 #Create calo clusters
 from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
@@ -225,19 +290,16 @@ towers = CaloTowerTool("towers",
                        ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                        ecalEndcapReadoutName = ecalEndcapReadoutName,
                        ecalFwdReadoutName = ecalFwdReadoutName,
-                       # hcalBarrelReadoutName = hcalBarrelReadoutName,
-                       # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
-                       hcalBarrelReadoutName = "",
-                       hcalExtBarrelReadoutName = "",
+                       hcalBarrelReadoutName =  hcalBarrelPhiEtaReadoutName,
+                       hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
                        hcalEndcapReadoutName = hcalEndcapReadoutName,
-                       hcalFwdReadoutName = hcalFwdReadoutName)
+                       hcalFwdReadoutName = hcalFwdReadoutName,
+                       OutputLevel=INFO)
 towers.ecalBarrelCells.Path = "ECalBarrelCells"
 towers.ecalEndcapCells.Path = "ECalEndcapCells"
 towers.ecalFwdCells.Path = "ECalFwdCells"
-# towers.hcalBarrelCells.Path = "HCalBarrelCells"
-# towers.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
-towers.hcalBarrelCells.Path = "emptyCaloCells"
-towers.hcalExtBarrelCells.Path = "emptyCaloCells"
+towers.hcalBarrelCells.Path = "newHCalBarrelCells"
+towers.hcalExtBarrelCells.Path = "newHCalExtBarrelCells"
 towers.hcalEndcapCells.Path = "HCalEndcapCells"
 towers.hcalFwdCells.Path = "HCalFwdCells"
 
@@ -247,7 +309,8 @@ createclusters = CreateCaloClustersSlidingWindow("CreateCaloClusters",
                                                  nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
                                                  nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                  nEtaFinal = winEta, nPhiFinal = winPhi,
-                                                 energyThreshold = enThreshold)
+                                                 energyThreshold = enThreshold,
+                                                 OutputLevel=INFO)
 createclusters.clusters.Path = "caloClusters"
 
 # PODIO algorithm
@@ -271,10 +334,12 @@ audsvc.Auditors = [chra]
 out.AuditExecute = True
 
 list_of_algorithms = [podioinput,
-                      createemptycells,
-                      createclusters]
+                      createemptycells]
 if noise:
-    list_of_algorithms += [createEcalBarrelCells, createclustersNoise, correctedClustersNoise]
+    list_of_algorithms += [createEcalBarrelCells, createHcalBarrelCells, positionsHcalNoise, resegmentHcalNoise, createclustersNoise]
+else:
+    list_of_algorithms += [positionsHcal, resegmentHcal, positionsExtHcal, resegmentExtHcal, createclusters] 
+
 
 list_of_algorithms += [out]
 

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -10,7 +10,7 @@ simparser.add_argument("--addElectronicsNoise", action='store_true', help="Add e
 simparser.add_argument('--winEta', type=int, default=7, help='Size of the final cluster in eta')
 simparser.add_argument('--winPhi', type=int, default=19, help='Size of the final cluster in phi')
 simparser.add_argument('--enThreshold', type=float, default=3., help='Energy threshold of the seeding clusters [GeV]')
-simparser.add_argument('--mu', type=int, default=0, help='Pileup scenario')
+simparser.add_argument('--mu', type=int, default=1000, help='Pileup scenario')
 
 simargs, _ = simparser.parse_known_args()
 
@@ -198,12 +198,10 @@ if noise:
     #                                         noiseTool = noiseEndcap,
     #                                         hits="ECalEndcapCells",
     #                                         cells="ECalEndcapCellsNoise")
- 
-
 
     # additionally for HCal
     from Configurables import CreateVolumeCaloPositions
-    positionsHcalNoise = CreateVolumeCaloPositions("positionsHcalNoise", OutputLevel = INFO)
+    positionsHcalNoise = CreateVolumeCaloPositions("positionsHcalNoise")
     positionsHcalNoise.hits.Path = "HCalBarrelCellsNoise"
     positionsHcalNoise.positionedHits.Path = "HCalBarrelPositionsNoise"
     
@@ -229,7 +227,7 @@ if noise:
                            ecalEndcapReadoutName = ecalEndcapReadoutName,
                            ecalFwdReadoutName = ecalFwdReadoutName,
                            hcalBarrelReadoutName = hcalBarrelPhiEtaReadoutName,
-                           hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
+                           hcalExtBarrelReadoutName = "",
                            hcalEndcapReadoutName = hcalEndcapReadoutName,
                            hcalFwdReadoutName = hcalFwdReadoutName)
     towersNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
@@ -245,16 +243,15 @@ if noise:
                                                           nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
                                                           nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                           nEtaFinal = winEta, nPhiFinal = winPhi,
-                                                          energyThreshold = enThreshold,
-                                                          OutputLevel = INFO)
+                                                          energyThreshold = enThreshold)
     createclustersNoise.clusters.Path = "caloClustersNoise"
 
 # additionally for HCal
 from Configurables import CreateVolumeCaloPositions
-positionsHcal = CreateVolumeCaloPositions("positionsHcal", OutputLevel = INFO)
+positionsHcal = CreateVolumeCaloPositions("positionsHcal")
 positionsHcal.hits.Path = "HCalBarrelCells"
 positionsHcal.positionedHits.Path = "HCalBarrelPositions"
-positionsExtHcal = CreateVolumeCaloPositions("positionsExtHcal", OutputLevel = INFO)
+positionsExtHcal = CreateVolumeCaloPositions("positionsExtHcal")
 positionsExtHcal.hits.Path = "HCalExtBarrelCells"
 positionsExtHcal.positionedHits.Path = "HCalExtBarrelPositions"
 
@@ -267,7 +264,6 @@ resegmentHcal = RedoSegmentation("ReSegmentationHcal",
                              # new bitfield (readout), with new segmentation
                              newReadoutName = hcalBarrelPhiEtaReadoutName,
                              debugPrint = 10,
-                             OutputLevel = INFO,
                              inhits = "HCalBarrelPositions",
 outhits = "newHCalBarrelCells")
 resegmentExtHcal = RedoSegmentation("ReSegmentationExtHcal",
@@ -278,7 +274,6 @@ resegmentExtHcal = RedoSegmentation("ReSegmentationExtHcal",
                              # new bitfield (readout), with new segmentation
                              newReadoutName = hcalExtBarrelPhiEtaReadoutName,
                              debugPrint = 10,
-                             OutputLevel = INFO,
                              inhits = "HCalExtBarrelPositions",
 outhits = "newHCalExtBarrelCells")
 
@@ -309,8 +304,7 @@ createclusters = CreateCaloClustersSlidingWindow("CreateCaloClusters",
                                                  nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
                                                  nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                  nEtaFinal = winEta, nPhiFinal = winPhi,
-                                                 energyThreshold = enThreshold,
-                                                 OutputLevel=INFO)
+                                                 energyThreshold = enThreshold)
 createclusters.clusters.Path = "caloClusters"
 
 # PODIO algorithm

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -10,7 +10,7 @@ simparser.add_argument("--addElectronicsNoise", action='store_true', help="Add e
 simparser.add_argument('--winEta', type=int, default=7, help='Size of the final cluster in eta')
 simparser.add_argument('--winPhi', type=int, default=19, help='Size of the final cluster in phi')
 simparser.add_argument('--enThreshold', type=float, default=3., help='Energy threshold of the seeding clusters [GeV]')
-simparser.add_argument('--mu', type=int, default=1000, help='Pileup scenario')
+simparser.add_argument('--mu', type=int, default=0, help='Pileup scenario')
 
 simargs, _ = simparser.parse_known_args()
 

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -44,7 +44,7 @@ pileup = simargs.mu
 print "number of events = ", num_events
 print "input name: ", input_name
 print "output name: ", output_name
-print "electronic noise in ECAL: ", noise
+print "electronic noise in E and HCAL: ", noise
 print "detectors are taken from: ", path_to_detector
 print "cluster eta size: ", winEta
 print "cluster phi size: ", winPhi
@@ -64,12 +64,14 @@ from Gaudi.Configuration import *
 detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                   path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
                   path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
-                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
-                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
-                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
-                  path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
-                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
-                  path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Shielding.xml']
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml']
+if not noise:
+    detectors_to_use += [path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml']
+    
+detectors_to_use += [path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
+                     path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
+                     path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
+                     path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Shielding.xml']
 
 from Configurables import GeoSvc
 geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use)
@@ -202,7 +204,7 @@ if noise:
     from Configurables import RedoSegmentation
     resegmentHcalNoise = RedoSegmentation("ReSegmentationHcalNoise",
                                           # old bitfield (readout)
-                                     oldReadoutName = hcalBarrelReadoutName,
+                                          oldReadoutName = hcalBarrelReadoutName,
                                           # # specify which fields are going to be altered (deleted/rewritten)
                                           # oldSegmentationIds = ["eta","phi"],
                                           # new bitfield (readout), with new segmentation
@@ -238,7 +240,7 @@ if noise:
                                                           nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                           nEtaFinal = winEta, nPhiFinal = winPhi,
                                                           energyThreshold = enThreshold,
-                                                          OutputLevel = DEBUG)
+                                                          OutputLevel = INFO)
     createclustersNoise.clusters.Path = "caloClustersNoise"
 
 # additionally for HCal

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -1,4 +1,4 @@
-import argparse
+import argparse, math
 simparser = argparse.ArgumentParser()
 
 simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
@@ -24,6 +24,21 @@ noise = simargs.addElectronicsNoise
 path_to_detector = simargs.detectorPath
 winEta = simargs.winEta
 winPhi = simargs.winPhi
+winEtaPos = int(math.floor(winEta*2./4.))
+winPhiPos = int(math.floor(winPhi*2./4.))
+winEtaDup = int(math.floor(winEta*3./4.))
+winPhiDup = int(math.floor(winPhi*2./4.))
+
+## make sure that window size is odd
+if winEtaPos %2 == 0:
+    winEtaPos = winEtaPos +1 
+if winPhiPos %2 == 0:
+    winPhiPos = winPhiPos +1 
+if winEtaDup %2 == 0:
+    winEtaDup = winEtaDup +1 
+if winPhiDup %2 == 0:
+    winPhiDup = winPhiDup +1 
+
 enThreshold = simargs.enThreshold
 pileup = simargs.mu
 print "number of events = ", num_events
@@ -31,6 +46,12 @@ print "input name: ", input_name
 print "output name: ", output_name
 print "electronic noise in ECAL: ", noise
 print "detectors are taken from: ", path_to_detector
+print "cluster eta size: ", winEta
+print "cluster phi size: ", winPhi
+print "pos cluster eta size: ", winEtaPos
+print "pos cluster phi size: ", winPhiPos
+print "dup cluster eta size: ", winEtaDup
+print "dup cluster phi size: ", winPhiDup
 print "final cluster eta size: ", winEta
 print "final cluster phi size: ", winPhi
 print "energy threshold for seeding cluster [GeV]: ", enThreshold
@@ -43,8 +64,8 @@ from Gaudi.Configuration import *
 detectors_to_use=[path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_DectEmptyMaster.xml',
                   path_to_detector+'/Detector/DetFCChhTrackerTkLayout/compact/Tracker.xml',
                   path_to_detector+'/Detector/DetFCChhECalInclined/compact/FCChh_ECalBarrel_withCryostat.xml',
-                  # path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
-                  # path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalBarrel_TileCal.xml',
+                  path_to_detector+'/Detector/DetFCChhHCalTile/compact/FCChh_HCalExtendedBarrel_TileCal.xml',
                   path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Endcaps_coneCryo.xml',
                   path_to_detector+'/Detector/DetFCChhCalDiscs/compact/Forward_coneCryo.xml',
                   path_to_detector+'/Detector/DetFCChhBaseline1/compact/FCChh_Solenoids.xml',
@@ -66,9 +87,18 @@ ecalBarrelPileupHistName = "h_pileup_layer"
 ecalEndcapNoiseHistName = "h_elecNoise_fcc_"
 # HCAL readouts
 hcalBarrelReadoutName = "HCalBarrelReadout"
+hcalBarrelPhiEtaReadoutName = "BarHCal_Readout_phieta"
 hcalExtBarrelReadoutName = "HCalExtBarrelReadout"
+hcalExtBarrelPhiEtaReadoutName = "ExtBarHCal_Readout_phieta"
 hcalEndcapReadoutName = "HECPhiEta"
 hcalFwdReadoutName = "HFwdPhiEta"
+# active material identifier name
+hcalIdentifierName = [ "module", "row", "layer" ]
+# active material volume name
+hcalVolumeName = [ "moduleVolume", "wedgeVolume", "layerVolume" ]
+# HCAL bitfield names& values
+hcalFieldNames = ["system"] 
+hcalFieldValues = [8]
 ##############################################################################################################
 #######                                           INPUT                                          #############
 ##############################################################################################################
@@ -80,8 +110,8 @@ podioinput = PodioInput("in", collections = ["GenVertices",
                                              "ECalBarrelCells",
                                              "ECalEndcapCells",
                                              "ECalFwdCells",
-                                             # "HCalBarrelCells",
-                                             # "HCalExtBarrelCells",
+                                             "HCalBarrelCells",
+                                             "HCalExtBarrelCells",
                                              "HCalEndcapCells",
                                              "HCalFwdCells"])
 
@@ -94,7 +124,7 @@ createemptycells.cells.Path = "emptyCaloCells"
 
 from Configurables import CreateCaloCells
 if noise:
-    from Configurables import NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool
+    from Configurables import NoiseCaloCellsFromFileTool, NoiseCaloCellsFlatTool, TubeLayerPhiEtaCaloTool, NestedVolumesCaloTool
 # 1. ECAL BARREL
 if noise:
     noiseBarrel = NoiseCaloCellsFromFileTool("NoiseBarrel",
@@ -120,6 +150,24 @@ if noise:
                                             noiseTool = noiseBarrel,
                                             hits="ECalBarrelCells",
                                             cells="ECalBarrelCellsNoise")
+    # 2. HCAL BARREL
+    noiseHcal = NoiseCaloCellsFlatTool("HCalNoise", cellNoise = 0.009)
+
+    hcalgeo = NestedVolumesCaloTool("HcalGeo",
+                                    activeVolumeName = hcalVolumeName,
+                                    activeFieldName = hcalIdentifierName,
+                                    readoutName = hcalBarrelReadoutName,
+                                    fieldNames = hcalFieldNames,
+                                    fieldValues = hcalFieldValues,
+                                    OutputLevel = INFO)
+    
+    createHcalBarrelCells =CreateCaloCells("CreateHCalBarrelCells", geometryTool = hcalgeo,
+                                           doCellCalibration = False, addCellNoise = True,
+                                           filterCellNoise = False, noiseTool = noiseHcal,
+                                           OutputLevel = INFO) 
+    createHcalBarrelCells.hits.Path ="HCalBarrelCells" 
+    createHcalBarrelCells.cells.Path ="HCalBarrelCellsNoise"
+
     # noiseEndcap = NoiseCaloCellsFromFileTool("NoiseEndcap",
     #                                          readoutName = ecalEndcapReadoutName,
     #                                          noiseFileName = ecalEndcapNoisePath,
@@ -142,7 +190,29 @@ if noise:
     #                                         noiseTool = noiseEndcap,
     #                                         hits="ECalEndcapCells",
     #                                         cells="ECalEndcapCellsNoise")
-    #Create calo clusters
+ 
+
+
+    # additionally for HCal
+    from Configurables import CreateVolumeCaloPositions
+    positionsHcalNoise = CreateVolumeCaloPositions("positionsHcalNoise", OutputLevel = INFO)
+    positionsHcalNoise.hits.Path = "HCalBarrelCellsNoise"
+    positionsHcalNoise.positionedHits.Path = "HCalBarrelPositionsNoise"
+    
+    from Configurables import RedoSegmentation
+    resegmentHcalNoise = RedoSegmentation("ReSegmentationHcalNoise",
+                                          # old bitfield (readout)
+                                     oldReadoutName = hcalBarrelReadoutName,
+                                          # # specify which fields are going to be altered (deleted/rewritten)
+                                          # oldSegmentationIds = ["eta","phi"],
+                                          # new bitfield (readout), with new segmentation
+                                          newReadoutName = hcalBarrelPhiEtaReadoutName,
+                                          debugPrint = 10,
+                                          OutputLevel = INFO,
+                                          inhits = "HCalBarrelPositionsNoise",
+                                          outhits = "newHCalBarrelCellsNoise")
+    
+   #Create calo clusters
     from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
     from GaudiKernel.PhysicalConstants import pi
     towersNoise = CaloTowerTool("towersNoise",
@@ -150,42 +220,59 @@ if noise:
                            ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                            ecalEndcapReadoutName = ecalEndcapReadoutName,
                            ecalFwdReadoutName = ecalFwdReadoutName,
-                           # hcalBarrelReadoutName = hcalBarrelReadoutName,
-                           # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
-                           hcalBarrelReadoutName = "",
-                           hcalExtBarrelReadoutName = "",
+                           hcalBarrelReadoutName = hcalBarrelPhiEtaReadoutName,
+                           hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
                            hcalEndcapReadoutName = hcalEndcapReadoutName,
                            hcalFwdReadoutName = hcalFwdReadoutName)
     towersNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     towersNoise.ecalEndcapCells.Path = "ECalEndcapCells"
     towersNoise.ecalFwdCells.Path = "ECalFwdCells"
-    # towersNoise.hcalBarrelCells.Path = "HCalBarrelCells"
-    # towersNoise.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
-    towersNoise.hcalBarrelCells.Path = "emptyCaloCells"
+    towersNoise.hcalBarrelCells.Path = "newHCalBarrelCellsNoise"
     towersNoise.hcalExtBarrelCells.Path = "emptyCaloCells"
     towersNoise.hcalEndcapCells.Path = "HCalEndcapCells"
     towersNoise.hcalFwdCells.Path = "HCalFwdCells"
     createclustersNoise = CreateCaloClustersSlidingWindow("CreateCaloClustersNoise",
-                                                     towerTool = towersNoise,
-                                                     nEtaWindow = 7, nPhiWindow = 15,
-                                                     nEtaPosition = 3, nPhiPosition = 11,
-                                                     nEtaDuplicates = 5, nPhiDuplicates = 11,
-                                                     nEtaFinal = winEta, nPhiFinal = winPhi,
-                                                     energyThreshold = enThreshold)
+                                                          towerTool = towersNoise,
+                                                          nEtaWindow = winEta, nPhiWindow = winPhi,
+                                                          nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
+                                                          nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
+                                                          nEtaFinal = winEta, nPhiFinal = winPhi,
+                                                          energyThreshold = enThreshold,
+                                                          OutputLevel = DEBUG)
     createclustersNoise.clusters.Path = "caloClustersNoise"
-    from Configurables import CorrectCluster
-    correctClusters = CorrectCluster("CorrectCluster",
-                                     energyAxis = energy,
-                                     numLayers = 8,
-                                     etaValues = [0,0.25],
-                                     presamplerShiftP0 = [0.05938, 0.05938],
-                                     presamplerShiftP1 = [0.0001833,0.0001833],
-                                     presamplerScaleP0  = [2.4, 2.4],
-                                     presamplerScaleP1  = [-0.006838, -0.006838],
-                                     mu = pileup,
-                                     noiseFileName = ecalBarrelPileupNoisePath)
-    correctClusters.clusters.Path = "caloClustersNoise",
-    correctClusters.correctedClusters.Path = "caloClustersCorrected"
+
+# additionally for HCal
+from Configurables import CreateVolumeCaloPositions
+positionsHcal = CreateVolumeCaloPositions("positionsHcal", OutputLevel = INFO)
+positionsHcal.hits.Path = "HCalBarrelCells"
+positionsHcal.positionedHits.Path = "HCalBarrelPositions"
+positionsExtHcal = CreateVolumeCaloPositions("positionsExtHcal", OutputLevel = INFO)
+positionsExtHcal.hits.Path = "HCalExtBarrelCells"
+positionsExtHcal.positionedHits.Path = "HCalExtBarrelPositions"
+
+from Configurables import RedoSegmentation
+resegmentHcal = RedoSegmentation("ReSegmentationHcal",
+                             # old bitfield (readout)
+                             oldReadoutName = hcalBarrelReadoutName,
+                             # # specify which fields are going to be altered (deleted/rewritten)
+                             # oldSegmentationIds = ["eta","phi"],
+                             # new bitfield (readout), with new segmentation
+                             newReadoutName = hcalBarrelPhiEtaReadoutName,
+                             debugPrint = 10,
+                             OutputLevel = INFO,
+                             inhits = "HCalBarrelPositions",
+outhits = "newHCalBarrelCells")
+resegmentExtHcal = RedoSegmentation("ReSegmentationExtHcal",
+                             # old bitfield (readout)
+                             oldReadoutName = hcalExtBarrelReadoutName,
+                             # # specify which fields are going to be altered (deleted/rewritten)
+                             # oldSegmentationIds = ["eta","phi"],
+                             # new bitfield (readout), with new segmentation
+                             newReadoutName = hcalExtBarrelPhiEtaReadoutName,
+                             debugPrint = 10,
+                             OutputLevel = INFO,
+                             inhits = "HCalExtBarrelPositions",
+outhits = "newHCalExtBarrelCells")
 
 #Create calo clusters
 from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
@@ -195,29 +282,27 @@ towers = CaloTowerTool("towers",
                        ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                        ecalEndcapReadoutName = ecalEndcapReadoutName,
                        ecalFwdReadoutName = ecalFwdReadoutName,
-                       # hcalBarrelReadoutName = hcalBarrelReadoutName,
-                       # hcalExtBarrelReadoutName = hcalExtBarrelReadoutName,
-                       hcalBarrelReadoutName = "",
-                       hcalExtBarrelReadoutName = "",
+                       hcalBarrelReadoutName =  hcalBarrelPhiEtaReadoutName,
+                       hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
                        hcalEndcapReadoutName = hcalEndcapReadoutName,
-                       hcalFwdReadoutName = hcalFwdReadoutName)
+                       hcalFwdReadoutName = hcalFwdReadoutName,
+                       OutputLevel=DEBUG)
 towers.ecalBarrelCells.Path = "ECalBarrelCells"
 towers.ecalEndcapCells.Path = "ECalEndcapCells"
 towers.ecalFwdCells.Path = "ECalFwdCells"
-# towers.hcalBarrelCells.Path = "HCalBarrelCells"
-# towers.hcalExtBarrelCells.Path = "HCalExtBarrelCells"
-towers.hcalBarrelCells.Path = "emptyCaloCells"
-towers.hcalExtBarrelCells.Path = "emptyCaloCells"
+towers.hcalBarrelCells.Path = "newHCalBarrelCells"
+towers.hcalExtBarrelCells.Path = "newHCalExtBarrelCells"
 towers.hcalEndcapCells.Path = "HCalEndcapCells"
 towers.hcalFwdCells.Path = "HCalFwdCells"
 
 createclusters = CreateCaloClustersSlidingWindow("CreateCaloClusters",
                                                  towerTool = towers,
-                                                 nEtaWindow = 7, nPhiWindow = 15,
-                                                 nEtaPosition = 3, nPhiPosition = 11,
-                                                 nEtaDuplicates = 5, nPhiDuplicates = 11,
+                                                 nEtaWindow = winEta, nPhiWindow = winPhi,
+                                                 nEtaPosition = winEtaPos, nPhiPosition = winPhiPos,
+                                                 nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                  nEtaFinal = winEta, nPhiFinal = winPhi,
-                                                 energyThreshold = enThreshold)
+                                                 energyThreshold = enThreshold,
+                                                 OutputLevel=DEBUG)
 createclusters.clusters.Path = "caloClusters"
 
 # PODIO algorithm
@@ -241,10 +326,12 @@ audsvc.Auditors = [chra]
 out.AuditExecute = True
 
 list_of_algorithms = [podioinput,
-                      createemptycells,
-                      createclusters]
+                      createemptycells]
 if noise:
-    list_of_algorithms += [createEcalBarrelCells, createclustersNoise, correctedClustersNoise]
+    list_of_algorithms += [createEcalBarrelCells, createHcalBarrelCells, positionsHcalNoise, resegmentHcalNoise, createclustersNoise]
+else:
+    list_of_algorithms += [positionsHcal, resegmentHcal, positionsExtHcal, resegmentExtHcal, createclusters] 
+
 
 list_of_algorithms += [out]
 

--- a/config/recSlidingWindow.py
+++ b/config/recSlidingWindow.py
@@ -77,7 +77,7 @@ geoservice = GeoSvc("GeoSvc", detectors = detectors_to_use)
 # ECAL readouts
 ecalBarrelReadoutName = "ECalBarrelEta"
 ecalBarrelReadoutNamePhiEta = "ECalBarrelPhiEta"
-ecalEndcapReadoutName = "EMECPhiEtaReco"
+ecalEndcapReadoutName = "EMECPhiEta"
 ecalFwdReadoutName = "EMFwdPhiEta"
 ecalBarrelNoisePath = "/afs/cern.ch/user/a/azaborow/public/FCCSW/elecNoise_ecalBarrel_50Ohm_traces2_2shieldWidth_noise.root"
 ecalEndcapNoisePath = "/afs/cern.ch/user/n/novaj/public/elecNoise_emec_6layers.root"
@@ -216,7 +216,7 @@ if noise:
     from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
     from GaudiKernel.PhysicalConstants import pi
     towersNoise = CaloTowerTool("towersNoise",
-                           deltaEtaTower = 0.01, deltaPhiTower = 2*pi/704.,
+                           deltaEtaTower = 0.01, deltaPhiTower = 2*pi/256.,
                            ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                            ecalEndcapReadoutName = ecalEndcapReadoutName,
                            ecalFwdReadoutName = ecalFwdReadoutName,
@@ -278,7 +278,7 @@ outhits = "newHCalExtBarrelCells")
 from Configurables import CreateCaloClustersSlidingWindow, CaloTowerTool
 from GaudiKernel.PhysicalConstants import pi
 towers = CaloTowerTool("towers",
-                       deltaEtaTower = 0.01, deltaPhiTower = 2*pi/704.,
+                       deltaEtaTower = 0.01, deltaPhiTower = 2*pi/256.,
                        ecalBarrelReadoutName = ecalBarrelReadoutNamePhiEta,
                        ecalEndcapReadoutName = ecalEndcapReadoutName,
                        ecalFwdReadoutName = ecalFwdReadoutName,
@@ -286,7 +286,7 @@ towers = CaloTowerTool("towers",
                        hcalExtBarrelReadoutName = hcalExtBarrelPhiEtaReadoutName,
                        hcalEndcapReadoutName = hcalEndcapReadoutName,
                        hcalFwdReadoutName = hcalFwdReadoutName,
-                       OutputLevel=DEBUG)
+                       OutputLevel=INFO)
 towers.ecalBarrelCells.Path = "ECalBarrelCells"
 towers.ecalEndcapCells.Path = "ECalEndcapCells"
 towers.ecalFwdCells.Path = "ECalFwdCells"
@@ -302,7 +302,7 @@ createclusters = CreateCaloClustersSlidingWindow("CreateCaloClusters",
                                                  nEtaDuplicates = winEtaDup, nPhiDuplicates = winPhiDup,
                                                  nEtaFinal = winEta, nPhiFinal = winPhi,
                                                  energyThreshold = enThreshold,
-                                                 OutputLevel=DEBUG)
+                                                 OutputLevel=INFO)
 createclusters.clusters.Path = "caloClusters"
 
 # PODIO algorithm

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -39,6 +39,7 @@ print 'energy thresholds for reconstruction: ', sigma1, '-', sigma2, '-', sigma3
 print "detectors are taken from: ", path_to_detector
 
 print "add pileup events to signal: ", addPUevents
+input_pileup_name = []
 if addPUevents:
     input_pileup_name = simargs.inPileupFileNames
     print "PU", (puEvents)
@@ -136,7 +137,6 @@ recreateEcalBarrelCells.cells.Path="ECalBarrelCellsRedo"
 #######                                       ADD PILEUP EVENTS                              #############
 ##############################################################################################################
 if addPUevents:
-
     # edm data from simulation: hits and positioned hits
     from Configurables import PileupCaloHitMergeTool
     ecalbarrelmergetool = PileupCaloHitMergeTool("ECalBarrelHitMerge")
@@ -533,7 +533,7 @@ list_of_algorithms = [podioinput,
 if addPUevents:
      list_of_algorithms += [overlay]
    
-if elNoise or puNoise:
+elif elNoise or puNoise:
     list_of_algorithms += [createEcalBarrelCells, createHcalBarrelCells, createTopoClustersNoise, positionsClusterBarrelNoise]
 
 else:

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -36,6 +36,7 @@ print "input name: ", input_name
 print "output name: ", output_name
 print 'energy thresholds for reconstruction: ', sigma1, '-', sigma2, '-', sigma3
 print "detectors are taken from: ", path_to_detector
+print "added pileup: ",addedPU
 
 print "add electronic noise in Barrel: ", elNoise
 print "add pileup noise in Barrel: ", puNoise
@@ -102,7 +103,11 @@ inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_seg
 from Configurables import ApplicationMgr, FCCDataSvc, PodioInput, PodioOutput
 podioevent = FCCDataSvc("EventDataSvc", input=input_name)
 
-podioinput = PodioInput("PodioReader", collections = ["ECalBarrelCells", "HCalBarrelCells","GenParticles","GenVertices"], OutputLevel = DEBUG)
+if addedPU != 0:
+    inputCellCollectionECalBarrel = "addedPUECalBarrelCells"   
+    inputCellCollectionHCalBarrel = "addedPUHCalBarrelCells"
+    
+podioinput = PodioInput("PodioReader", collections = [inputCellCollectionECalBarrel, inputCellCollectionHCalBarrel,"GenParticles","GenVertices"], OutputLevel = DEBUG)
 
 ##############################################################################################################
 #######                                       CELL POSITIONS  TOOLS                              #############
@@ -154,7 +159,7 @@ if elNoise:
     inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_electronicsNoiseLevel.root"
     # Apply cell thresholds for electronics noise only if no pileup events have been merged
     if addedPU != 0:
-        inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(addedPU)+".root"
+        inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_forPU100_electronicsPileup_mu"+str(addedPU)+".root"
         
     from Configurables import CreateCaloCells, NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool, CalibrateCaloHitsTool, NoiseCaloCellsFlatTool, NestedVolumesCaloTool
     # ECal Barrel noise

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -1,4 +1,4 @@
-import argparse, os
+import argparse
 simparser = argparse.ArgumentParser()
 
 simparser.add_argument('--inName', type=str, help='Name of the input file', required=True)
@@ -165,7 +165,7 @@ if elNoise:
                                              activeFieldName = "layer",
                                              addPileup = False,
                                              numRadialLayers = 8)
-    
+
     # add noise, create all existing cells in detector
     barrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
                                              readoutName = ecalBarrelReadoutName,
@@ -223,8 +223,7 @@ if elNoise:
     createTopoInputNoise.hcalFwdCells.Path = "emptyCaloCells"
 
     readNoisyCellsMap = TopoCaloNoisyCells("ReadNoisyCellsMap",
-                                           fileName = inputNoisePerCell,
-                                           OutputLevel = DEBUG)
+                                           fileName = inputNoisePerCell)
 
     # Topo-Cluster Algorithm
     # Seed and neighbour thresholds 4 - 2 - 0 w/noise
@@ -473,5 +472,5 @@ ApplicationMgr(
     TopAlg = list_of_algorithms,
     EvtSel = 'NONE',
     EvtMax   = num_events,
-    ExtSvc = [geoservice, podioevent, audsvc],
-    OutputLevel = INFO)
+    ExtSvc = [geoservice, podioevent, audsvc]
+)

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -251,8 +251,6 @@ if elNoise:
                                             hits="ECalBarrelCellsRedo",
                                             cells="ECalBarrelCellsNoise")
 
-    inputCellCollectionECalBarrel = "ECalBarrelCellsNoise"
-
     # HCal Barrel noise
     noiseHcal = NoiseCaloCellsFlatTool("HCalNoise", cellNoise = 0.009)
 
@@ -273,8 +271,6 @@ if elNoise:
     createHcalBarrelCells.hits.Path="HCalBarrelCells"
     createHcalBarrelCells.cells.Path="HCalBarrelCellsNoise"
 
-    inputCellCollectionECalBarrel = "HCalBarrelCellsNoise"
-
     # Create topo clusters
     from Configurables import CaloTopoClusterInputTool, CaloTopoCluster
     createTopoInputNoise = CaloTopoClusterInputTool("CreateTopoInputNoise",
@@ -286,10 +282,10 @@ if elNoise:
                                                     hcalEndcapReadoutName = "",
                                                     hcalFwdReadoutName = "",
                                                     OutputLevel = INFO)
-    createTopoInputNoise.ecalBarrelCells.Path = inputCellCollectionECalBarrel
+    createTopoInputNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     createTopoInputNoise.ecalEndcapCells.Path = "emptyCaloCells"
     createTopoInputNoise.ecalFwdCells.Path = "emptyCaloCells"
-    createTopoInputNoise.hcalBarrelCells.Path = inputCellCollectionHCalBarrel
+    createTopoInputNoise.hcalBarrelCells.Path = "HCalBarrelCellsNoise"
     createTopoInputNoise.hcalExtBarrelCells.Path = "emptyCaloCells"
     createTopoInputNoise.hcalEndcapCells.Path = "emptyCaloCells"
     createTopoInputNoise.hcalFwdCells.Path = "emptyCaloCells"
@@ -363,8 +359,6 @@ if puNoise:
                                             hits="ECalBarrelCellsRedo",
                                             cells="ECalBarrelCellsNoise")
     
-    inputCellCollectionECalBarrel = "ECalBarrelCellsNoise"
-
     # HCal Barrel noise
     noiseHcal = NoiseCaloCellsFromFileTool("NoiseHCalBarrel",
                                            readoutName = hcalBarrelReadoutName,
@@ -391,9 +385,7 @@ if puNoise:
                                             OutputLevel = INFO)
     createHcalBarrelCells.hits.Path="HCalBarrelCells"
     createHcalBarrelCells.cells.Path="HCalBarrelCellsNoise"
-    
-    inputCellCollectionHCalBarrel = "HCalBarrelCellsNoise"
-   
+       
     # Create topo clusters
     from Configurables import CaloTopoClusterInputTool, CaloTopoCluster
     createTopoInputNoise = CaloTopoClusterInputTool("CreateTopoInputNoise",
@@ -405,10 +397,10 @@ if puNoise:
                                                     hcalEndcapReadoutName = "",
                                                     hcalFwdReadoutName = "",
                                                     OutputLevel = DEBUG)
-    createTopoInputNoise.ecalBarrelCells.Path = inputCellCollectionECalBarrel
+    createTopoInputNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     createTopoInputNoise.ecalEndcapCells.Path = "emptyCaloCells"
     createTopoInputNoise.ecalFwdCells.Path = "emptyCaloCells"
-    createTopoInputNoise.hcalBarrelCells.Path =     inputCellCollectionHCalBarrel
+    createTopoInputNoise.hcalBarrelCells.Path =     "HCalBarrelCellsNoise"
     createTopoInputNoise.hcalExtBarrelCells.Path = "emptyCaloCells"
     createTopoInputNoise.hcalEndcapCells.Path = "emptyCaloCells"
     createTopoInputNoise.hcalFwdCells.Path = "emptyCaloCells"
@@ -456,6 +448,10 @@ if puNoise:
 readNoNoisyCellsMap = TopoCaloNoisyCells("ReadNoNoisyCellsMap",
                                          fileName = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_constNoiseLevel.root",
                                          OutputLevel = DEBUG)
+
+print "ECal cell collection used in Topo-clustering: ", inputCellCollectionECalBarrel
+print "HCal cell collection used in Topo-clustering: ", inputCellCollectionHCalBarrel
+
 # Create topo clusters
 from Configurables import CaloTopoClusterInputTool, CaloTopoCluster, TopoCaloNeighbours
 createTopoInput = CaloTopoClusterInputTool("CreateTopoInput",
@@ -535,7 +531,7 @@ list_of_algorithms = [podioinput,
                       createemptycells]
 
 if addPUevents:
-     list_of_algorithms += [overlay]
+     list_of_algorithms += [overlay, createTopoClusters, positionsClusterBarrel]
    
 elif elNoise or puNoise:
     list_of_algorithms += [createEcalBarrelCells, createHcalBarrelCells, createTopoClustersNoise, positionsClusterBarrelNoise]

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -7,7 +7,6 @@ simparser.add_argument('-N','--numEvents',  type=int, help='Number of simulation
 simparser.add_argument("--physics", action='store_true', help="Physics events")
 simparser.add_argument("--addElectronicsNoise", action='store_true', help="Add electronics noise (default: false)")
 simparser.add_argument("--addPileupNoise", action='store_true', help="Add pileup noise")
-simparser.add_argument("--mu", type=int, help="Number of pileup-events", default=0)
 simparser.add_argument('--sigma1', type=int, default=4, help='Energy threshold [in number of sigmas] for seeding')
 simparser.add_argument('--sigma2', type=int, default=2, help='Energy threshold [in number of sigmas] for neighbours')
 simparser.add_argument('--sigma3', type=int, default=0, help='Energy threshold [in number of sigmas] for last neighbours')
@@ -22,26 +21,30 @@ print "=================================="
 num_events = simargs.numEvents
 input_name = simargs.inName
 output_name = simargs.outName
-addedPU = simargs.pileup
 elNoise = simargs.addElectronicsNoise
 puNoise = simargs.addPileupNoise
-puEvents = simargs.mu
+puEvents = simargs.pileup
 sigma1 = simargs.sigma1
 sigma2 = simargs.sigma2
 sigma3 = simargs.sigma3
 path_to_detector = simargs.detectorPath
-
+addedPU = 0
 print "number of events = ", num_events
 print "input name: ", input_name
 print "output name: ", output_name
 print 'energy thresholds for reconstruction: ', sigma1, '-', sigma2, '-', sigma3
 print "detectors are taken from: ", path_to_detector
-print "added pileup: ",addedPU
 
 print "add electronic noise in Barrel: ", elNoise
 print "add pileup noise in Barrel: ", puNoise
 if puNoise:
-    print 'assuming %i pileup events '%(puEvents)
+    print 'adding noise corresponding to %i pileup events '%(puEvents)
+
+if not puNoise:
+    addedPU = simargs.pileup
+    print "added pileup: ",addedPU
+if addedPU!=0:
+    elNoise = True
 
 from Gaudi.Configuration import *
 ##############################################################################################################
@@ -107,7 +110,7 @@ if addedPU != 0:
     inputCellCollectionECalBarrel = "addedPUECalBarrelCells"   
     inputCellCollectionHCalBarrel = "addedPUHCalBarrelCells"
     
-podioinput = PodioInput("PodioReader", collections = [inputCellCollectionECalBarrel, inputCellCollectionHCalBarrel,"GenParticles","GenVertices"], OutputLevel = DEBUG)
+podioinput = PodioInput("PodioReader", collections = [inputCellCollectionECalBarrel, inputCellCollectionHCalBarrel, "GenParticles", "GenVertices"], OutputLevel = DEBUG)
 
 ##############################################################################################################
 #######                                       CELL POSITIONS  TOOLS                              #############
@@ -159,7 +162,7 @@ if elNoise:
     inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_electronicsNoiseLevel.root"
     # Apply cell thresholds for electronics noise only if no pileup events have been merged
     if addedPU != 0:
-        inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_forPU100_electronicsPileup_mu"+str(addedPU)+".root"
+        inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_forPU"+str(addedPU)+"_electronicsPileup.root"
         
     from Configurables import CreateCaloCells, NoiseCaloCellsFromFileTool, TubeLayerPhiEtaCaloTool, CalibrateCaloHitsTool, NoiseCaloCellsFlatTool, NestedVolumesCaloTool
     # ECal Barrel noise
@@ -167,6 +170,7 @@ if elNoise:
                                              readoutName = ecalBarrelReadoutName,
                                              noiseFileName = ecalBarrelNoisePath,
                                              elecNoiseHistoName = ecalBarrelNoiseHistName,
+                                             cellPositionsTool = ECalBcells,
                                              activeFieldName = "layer",
                                              addPileup = False,
                                              numRadialLayers = 8)
@@ -243,8 +247,7 @@ if elNoise:
                                               positionsHCalBarrelTool = HCalBcellVols,
                                               seedSigma = sigma1,
                                               neighbourSigma = sigma2,
-                                              lastNeighbourSigma = sigma3,
-                                              OutputLevel = INFO)
+                                              lastNeighbourSigma = sigma3)
     createTopoClustersNoise.clusters.Path = "caloClustersBarrelNoise"
     createTopoClustersNoise.clusterCells.Path = "caloClusterBarrelNoiseCells"
 
@@ -258,8 +261,7 @@ if elNoise:
                                                           positionsEMFwdTool = ECalFwdcells,
                                                           positionsHFwdTool = HCalFwdcells,
                                                           hits = "caloClusterBarrelNoiseCells",
-                                                          positionedHits = "caloClusterBarrelNoiseCellPositions",
-                                                          OutputLevel = INFO)
+                                                          positionedHits = "caloClusterBarrelNoiseCellPositions")
 
 ##############################################################################################################
 #######                          NOISE/NO NOISE TOOL FOR CLUSTER THRESHOLDS                      #############
@@ -311,15 +313,13 @@ if puNoise:
                                     activeFieldName = hcalIdentifierName,
                                     readoutName = hcalBarrelReadoutName,
                                     fieldNames = hcalFieldNames,
-                                    fieldValues = hcalFieldValues,
-                                    OutputLevel = INFO)
+                                    fieldValues = hcalFieldValues)
     
     createHcalBarrelCells = CreateCaloCells("CreateHCalBarrelCells",
                                             geometryTool = hcalgeo,
                                             doCellCalibration = False,
                                             addCellNoise = True, filterCellNoise = False,
-                                            noiseTool = noiseHcal,
-                                            OutputLevel = INFO)
+                                            noiseTool = noiseHcal)
     createHcalBarrelCells.hits.Path="HCalBarrelCells"
     createHcalBarrelCells.cells.Path="HCalBarrelCellsNoise"
        
@@ -332,8 +332,7 @@ if puNoise:
                                                     hcalBarrelReadoutName = hcalBarrelReadoutName,
                                                     hcalExtBarrelReadoutName = "",
                                                     hcalEndcapReadoutName = "",
-                                                    hcalFwdReadoutName = "",
-                                                    OutputLevel = DEBUG)
+                                                    hcalFwdReadoutName = "")
     createTopoInputNoise.ecalBarrelCells.Path = "ECalBarrelCellsNoise"
     createTopoInputNoise.ecalEndcapCells.Path = "emptyCaloCells"
     createTopoInputNoise.ecalFwdCells.Path = "emptyCaloCells"
@@ -343,8 +342,7 @@ if puNoise:
     createTopoInputNoise.hcalFwdCells.Path = "emptyCaloCells"
     
     readNoisyCellsMap = TopoCaloNoisyCells("ReadNoisyCellsMap",
-                                           fileName = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(puEvents)+".root",
-                                           OutputLevel = INFO)
+                                           fileName = "/afs/cern.ch/work/c/cneubuse/public/FCChh/inBfield/cellNoise_map_segHcal_noiseLevelElectronicsPileup_mu"+str(puEvents)+".root")
     
     # Topo-Cluster Algorithm
     # Seed and neighbour thresholds 4 - 2 - 0 w/noise
@@ -359,8 +357,7 @@ if puNoise:
                                               positionsHCalBarrelTool = HCalBcellVols,
                                               seedSigma = sigma1,
                                               neighbourSigma = sigma2,
-                                              lastNeighbourSigma = sigma3,
-                                              OutputLevel = DEBUG)
+                                              lastNeighbourSigma = sigma3)
     createTopoClustersNoise.clusters.Path = "caloClustersBarrelNoise"
     createTopoClustersNoise.clusterCells.Path = "caloClusterBarrelNoiseCells"
     
@@ -374,8 +371,7 @@ if puNoise:
                                                           positionsEMFwdTool = ECalFwdcells,
                                                           positionsHFwdTool = HCalFwdcells,
                                                           hits = "caloClusterBarrelNoiseCells",
-                                                          positionedHits = "caloClusterBarrelNoiseCellPositions",
-                                                          OutputLevel = INFO)
+                                                          positionedHits = "caloClusterBarrelNoiseCellPositions")
     
 ##############################################################################################################
 #######                                 TOPO-CLUSTERING                                          #############
@@ -450,7 +446,7 @@ out.outputCommands = ["drop *", "keep GenParticles", "keep GenVertices", "keep c
 out.filename = output_name
 
 if elNoise or puNoise:
-    out.outputCommands += ["keep ECalBarrelCellsNoise", "keep HCalBarrelCellsNoise", "keep caloClustersBarrelNoise","keep caloClusterBarrelNoiseCells",  "keep caloClusterBarrelCellPositions"]
+    out.outputCommands += ["keep ECalBarrelCellsNoise", "keep HCalBarrelCellsNoise", "keep caloClustersBarrelNoise","keep caloClusterBarrelNoiseCells",  "keep caloClusterBarrelNoiseCellPositions"]
 out.filename = output_name
 
 #CPU information
@@ -477,5 +473,6 @@ ApplicationMgr(
     TopAlg = list_of_algorithms,
     EvtSel = 'NONE',
     EvtMax   = num_events,
-    ExtSvc = [geoservice, podioevent, audsvc]
+    ExtSvc = [geoservice, podioevent, audsvc],
+    OutputLevel = INFO
 )

--- a/config/recTopoClusters.py
+++ b/config/recTopoClusters.py
@@ -136,19 +136,7 @@ recreateEcalBarrelCells.cells.Path="ECalBarrelCellsRedo"
 #######                                       ADD PILEUP EVENTS                              #############
 ##############################################################################################################
 if addPUevents:
-    # edm data from generation: particles and vertices
-    from Configurables import PileupParticlesMergeTool
-    particlemergetool = PileupParticlesMergeTool("ParticlesMerge")
-    # branchnames for the pileup
-    particlemergetool.genParticlesBranch = "GenParticles"
-    particlemergetool.genVerticesBranch = "GenVertices"
-    # branchnames for the signal
-    particlemergetool.signalGenParticles.Path = "GenParticles"
-    particlemergetool.signalGenVertices.Path = "GenVertices"
-    # branchnames for the output
-    particlemergetool.mergedGenParticles.Path = "pileupGenParticles"
-    particlemergetool.mergedGenVertices.Path = "pileupGenVertices"
-    
+
     # edm data from simulation: hits and positioned hits
     from Configurables import PileupCaloHitMergeTool
     ecalbarrelmergetool = PileupCaloHitMergeTool("ECalBarrelHitMerge")
@@ -230,6 +218,7 @@ readNeighboursMap = TopoCaloNeighbours("ReadNeighboursMap",
 ##############################################################################################################
 
 if elNoise:
+    # Apply cell thresholds for electronics noise only if no pileup events have been merged
     if not addPUevents:
         inputNoisePerCell = "/afs/cern.ch/work/c/cneubuse/public/FCChh/cellNoise_map_segHcal_electronicsNoiseLevel.root"
         
@@ -242,7 +231,7 @@ if elNoise:
                                              activeFieldName = "layer",
                                              addPileup = False,
                                              numRadialLayers = 8)
-
+    
     # add noise, create all existing cells in detector
     barrelGeometry = TubeLayerPhiEtaCaloTool("EcalBarrelGeo",
                                              readoutName = ecalBarrelReadoutName,
@@ -251,7 +240,7 @@ if elNoise:
                                              fieldNames = ["system"],
                                              fieldValues = [5],
                                              activeVolumesNumber = 8)
-
+    
     createEcalBarrelCells = CreateCaloCells("CreateECalBarrelCells",
                                             geometryTool = barrelGeometry,
                                             doCellCalibration=False, # already calibrated
@@ -262,7 +251,7 @@ if elNoise:
 
     # HCal Barrel noise
     noiseHcal = NoiseCaloCellsFlatTool("HCalNoise", cellNoise = 0.009)
-
+    
     hcalgeo = NestedVolumesCaloTool("HcalGeo",
                                     activeVolumeName = hcalVolumeName,
                                     activeFieldName = hcalIdentifierName,
@@ -279,7 +268,7 @@ if elNoise:
                                             OutputLevel = INFO)
     createHcalBarrelCells.hits.Path=inputCellCollectionHCalBarrel
     createHcalBarrelCells.cells.Path="HCalBarrelCellsNoise"
-
+    
     # Create topo clusters
     from Configurables import CaloTopoClusterInputTool, CaloTopoCluster
     createTopoInputNoise = CaloTopoClusterInputTool("CreateTopoInputNoise",
@@ -333,6 +322,7 @@ if elNoise:
                                                           hits = "caloClusterBarrelNoiseCells",
                                                           positionedHits = "caloClusterBarrelNoiseCellPositions",
                                                           OutputLevel = INFO)
+
 ##############################################################################################################
 #######                          NOISE/NO NOISE TOOL FOR CLUSTER THRESHOLDS                      #############
 ##############################################################################################################
@@ -556,4 +546,4 @@ ApplicationMgr(
     EvtSel = 'NONE',
     EvtMax   = num_events,
     ExtSvc = [geoservice, podioevent, audsvc],
-    )
+    OutputLevel = VERBOSE)

--- a/inits/mergePileupTracker.py
+++ b/inits/mergePileupTracker.py
@@ -1,0 +1,2 @@
+path_to_INIT = '/afs/cern.ch/user/j/jhrdinka/work/public/FCCSW/init_v091.sh'
+path_to_FCCSW = '/afs/cern.ch/user/j/jhrdinka/work/public/FCCSW'

--- a/inits/trackerMergedHits.py
+++ b/inits/trackerMergedHits.py
@@ -1,0 +1,1 @@
+path_to_INIT = '/afs/cern.ch/user/j/jhrdinka/public/FCCSW/init_v091.sh'path_to_FCCSW = '/afs/cern.ch/user/j/jhrdinka/public/FCCSW'

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -3,20 +3,26 @@ import sys
 import math
 import numpy as n
 import ROOT as r
-from ROOT import gSystem
-gSystem.Load("libCaloAnalysis")
-from ROOT import Decoder
 
-system_decoder = Decoder("system:4")
-ecalBarrel_decoder = Decoder("system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10")
-hcalBarrel_decoder = Decoder("system:4,module:8,row:9,layer:5")
-hcalExtBarrel_decoder = Decoder("system:4,module:8,row:9,layer:5")
-ecalEndcap_decoder = Decoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10")
-hcalEndcap_decoder = Decoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10")
-ecalFwd_decoder = Decoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10")
-hcalFwd_decoder = Decoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10")
-trackerBarrel_decoder = Decoder("system:4,layer:5,module:18,x:-15,z:-15")
-trackerEndcap_decoder = Decoder("system:4,posneg:1,disc:5,component:17,x:-15,z:-15")
+from ROOT import gSystem
+import platform, os
+if platform.system()=='Darwin':
+    gSystem.Load(os.environ['/cvmfs/sft.cern.ch/lcg/releases/DD4hep/01-05-2396f/x86_64-slc6-gcc62-opt/lib/'])
+result=gSystem.Load("libDDCorePlugins")
+from ROOT import dd4hep
+if result < 0:
+    print "No lib loadable!"
+
+system_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4")
+ecalBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,cryo:1,type:3,subtype:3,layer:8,eta:9,phi:10")
+hcalBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,module:8,row:9,layer:5")
+hcalExtBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,module:8,row:9,layer:5")
+ecalEndcap_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10")
+hcalEndcap_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:10,phi:10")
+ecalFwd_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10")
+hcalFwd_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,subsystem:1,type:3,subtype:3,layer:8,eta:11,phi:10")
+trackerBarrel_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,layer:5,module:18,x:-15,z:-15")
+trackerEndcap_decoder = dd4hep.DDSegmentation.BitFieldCoder("system:4,posneg:1,disc:5,component:17,x:-15,z:-15")
 
 lastECalBarrelLayer = int(7)
 lastECalEndcapLayer = int(39)
@@ -30,9 +36,8 @@ lastOuterTrackerNegECapLayer = int(33)
 lastFwdTrackerPosECapLayer = int(42)
 
 def systemID(cellid):
-    system_decoder.setValue(cellid)
-    return system_decoder["system"]
-    
+    return system_decoder.get(cellid, "system")
+
 def benchmarkCorr(ecal, ecal_last, ehad, ehad_first):
     a=0.978
     b=0.479
@@ -81,8 +86,6 @@ rec_detid = r.std.vector(int)()
 rec_bits = r.std.vector(float)()
 
 outfile=r.TFile(outfile_name,"recreate")
-#outfile.mkdir('ana')
-#r.gDirectory.cd('ana')
 outtree=r.TTree('events','Events')
 
 maxEvent = intree.GetEntries()
@@ -202,13 +205,12 @@ for event in intree:
 
     else:
         for c in event.HCalBarrelCellPositions:
-            hcalBarrel_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(hcalBarrel_decoder["layer"] + lastECalBarrelLayer + 1)
+            rec_layer.push_back(hcalBarrel_decoder.get(c.core.cellId, "layer") + lastECalBarrelLayer + 1)
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -221,13 +223,12 @@ for event in intree:
             numHits += 1
     
         for c in event.ECalBarrelCellPositions:
-            ecalBarrel_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(ecalBarrel_decoder["layer"])
+            rec_layer.push_back(ecalBarrel_decoder.get(c.core.cellId, "layer"))
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -240,13 +241,12 @@ for event in intree:
             numHits += 1
 
         for c in event.HCalExtBarrelCellPositions:
-            hcalExtBarrel_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(hcalExtBarrel_decoder["layer"] + lastECalBarrelLayer + 1)
+            rec_layer.push_back(hcalExtBarrel_decoder.get(c.core.cellId, "layer") + lastECalBarrelLayer + 1)
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -256,13 +256,12 @@ for event in intree:
             numHits += 1
             
         for c in event.ECalEndcapCellPositions:
-            ecalEndcap_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(ecalEndcap_decoder["layer"])
+            rec_layer.push_back(ecalEndcap_decoder.get(c.core.cellId, "layer"))
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -272,13 +271,12 @@ for event in intree:
             numHits += 1
 
         for c in event.HCalEndcapCellPositions:
-            hcalEndcap_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(hcalEndcap_decoder["layer"] + lastECalEndcapLayer + 1)
+            rec_layer.push_back(hcalEndcap_decoder.get(c.core.cellId, "layer") + lastECalEndcapLayer + 1)
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -288,13 +286,12 @@ for event in intree:
             numHits += 1
 
         for c in event.ECalFwdCellPositions:
-            ecalFwd_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(ecalFwd_decoder["layer"])
+            rec_layer.push_back(ecalFwd_decoder.get(c.core.cellId, "layer"))
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -304,13 +301,12 @@ for event in intree:
             numHits += 1
 
         for c in event.HCalFwdCellPositions:
-            hcalFwd_decoder.setValue(c.core.cellId)
             position = r.TVector3(c.position.x,c.position.y,c.position.z)
             rec_ene.push_back(c.core.energy)
             rec_eta.push_back(position.Eta())
             rec_phi.push_back(position.Phi())
             rec_pt.push_back(c.core.energy*position.Unit().Perp())
-            rec_layer.push_back(hcalFwd_decoder["layer"] + lastECalFwdLayer + 1)
+            rec_layer.push_back(hcalFwd_decoder.get(c.core.cellId, "layer") + lastECalFwdLayer + 1)
             rec_x.push_back(c.position.x/10.)
             rec_y.push_back(c.position.y/10.)
             rec_z.push_back(c.position.z/10.)
@@ -321,8 +317,6 @@ for event in intree:
 
         if event.GetBranchStatus("TrackerPositionedHits"):
             for c in event.TrackerPositionedHits:
-                trackerBarrel_decoder.setValue(c.core.cellId)
-                trackerEndcap_decoder.setValue(c.core.cellId)
                 position = r.TVector3(c.position.x,c.position.y,c.position.z)
                 rec_ene.push_back(c.core.energy)
                 rec_eta.push_back(position.Eta())
@@ -330,27 +324,27 @@ for event in intree:
                 rec_pt.push_back(c.core.energy*position.Unit().Perp())
                 sysID = systemID(c.core.cellId)
                 if  sysID == 0 :
-                    rec_layer.push_back(trackerBarrel_decoder["layer"])
+                    rec_layer.push_back(trackerBarrel_decoder.get(c.core.cellId, "layer"))
                 elif sysID == 1 :
-                    rec_layer.push_back(trackerBarrel_decoder["layer"] + lastInnerTrackerBarrelLayer + 1)
+                    rec_layer.push_back(trackerBarrel_decoder.get(c.core.cellId, "layer") + lastInnerTrackerBarrelLayer + 1)
                 elif sysID == 2 :
-                    posneg = trackerEndcap_decoder["posneg"]
+                    posneg = trackerEndcap_decoder.get(c.core.cellId, "posneg")
                     if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerBarrelLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastOuterTrackerBarrelLayer + 1)
                     else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerPosECapLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastInnerTrackerPosECapLayer + 1)
                 elif sysID == 3:
-                    posneg = trackerEndcap_decoder["posneg"]
+                    posneg = trackerEndcap_decoder.get(c.core.cellId, "posneg")
                     if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastInnerTrackerNegECapLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastInnerTrackerNegECapLayer + 1)
                     else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerPosECapLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastOuterTrackerPosECapLayer + 1)
                 else :
-                    posneg = trackerEndcap_decoder["posneg"]
+                    posneg = trackerEndcap_decoder.get(c.core.cellId, "posneg")
                     if posneg == 0 :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastOuterTrackerNegECapLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastOuterTrackerNegECapLayer + 1)
                     else :
-                        rec_layer.push_back(trackerEndcap_decoder["disc"] + lastFwdTrackerPosECapLayer + 1)
+                        rec_layer.push_back(trackerEndcap_decoder.get(c.core.cellId, "disc") + lastFwdTrackerPosECapLayer + 1)
                 rec_x.push_back(c.position.x/10.)
                 rec_y.push_back(c.position.y/10.)
                 rec_z.push_back(c.position.z/10.)

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -5,7 +5,6 @@ import numpy as n
 import ROOT as r
 
 from ROOT import gSystem
-gSystem.Load(os.environ['/cvmfs/sft.cern.ch/lcg/releases/DD4hep/01-05-2396f/x86_64-slc6-gcc62-opt/lib/'])
 result=gSystem.Load("libDDCorePlugins")
 from ROOT import dd4hep
 if result < 0:

--- a/python/Convert.py
+++ b/python/Convert.py
@@ -5,9 +5,7 @@ import numpy as n
 import ROOT as r
 
 from ROOT import gSystem
-import platform, os
-if platform.system()=='Darwin':
-    gSystem.Load(os.environ['/cvmfs/sft.cern.ch/lcg/releases/DD4hep/01-05-2396f/x86_64-slc6-gcc62-opt/lib/'])
+gSystem.Load(os.environ['/cvmfs/sft.cern.ch/lcg/releases/DD4hep/01-05-2396f/x86_64-slc6-gcc62-opt/lib/'])
 result=gSystem.Load("libDDCorePlugins")
 from ROOT import dd4hep
 if result < 0:

--- a/python/send.py
+++ b/python/send.py
@@ -110,6 +110,8 @@ def getJobInfo(argv):
             job_type = "reco/topoClusters/electronicsNoise"
         elif '--addPileupNoise' in argv:
             job_type = "reco/topoClusters/pileupNoise/"
+        elif '--addPileupToSignal' in argv:
+            job_type = "reco/topoClusters/electronicsNoise"
         else:
             job_type = "reco/topoClusters/noNoise"
         short_job_type = 'recTopo'
@@ -179,6 +181,7 @@ if __name__=="__main__":
     parser.add_argument("--addPileupNoise", action='store_true', help="Add pile-up noise in qudrature to electronics noise")
     parser.add_argument('--pileup', type=int,  required = '--mergePileup' in sys.argv or '--addPileupNoise' in sys.argv or '--addPileupToSignal' in sys.argv, help='Pileup')
     parser.add_argument("--tripletTracker", action="store_true", help="Use triplet tracker layout instead of baseline")
+    parser.add_argument('--addPileupToSignal', action="store_true", help='Add PU events to signal.')
 
     default_options,job_type,short_job_type,sim = getJobInfo(sys.argv)
     parser.add_argument('--jobOptions', type=str, default = default_options, help='Name of the job options run by FCCSW (default config/geantSim.py')
@@ -214,7 +217,6 @@ if __name__=="__main__":
     recoTopoClusterGroup.add_argument('--sigma1', type=int, default=4, help='Energy threshold [in number of sigmas] for seeding')
     recoTopoClusterGroup.add_argument('--sigma2', type=int, default=2, help='Energy threshold [in number of sigmas] for neighbours')
     recoTopoClusterGroup.add_argument('--sigma3', type=int, default=0, help='Energy threshold [in number of sigmas] for last neighbours')
-    recoTopoClusterGroup.add_argument("--addPileupToSignal", action='store_true', help="Add radomly PU evetnts to signal")
 
     args, _ = parser.parse_known_args()
 

--- a/python/send.py
+++ b/python/send.py
@@ -485,12 +485,12 @@ if __name__=="__main__":
         if args.noise:
             common_fccsw_command += ' --addElectronicsNoise'
         if args.addPileupNoise:
-            common_fccsw_command += ' --addPileupNoise --mu ' + str(args.pileup)
+            common_fccsw_command += ' --addPileupNoise --pileup ' + str(args.pileup)
         if args.physics:
             common_fccsw_command += ' --physics'
         if '--local' in sys.argv:
             common_fccsw_command += ' --detectorPath ' + path_to_FCCSW
-        if args.addPileupToSignal or  ( args.physics and args.mergePileup):
+        if args.physics and args.mergePileup:
             common_fccsw_command += ' --pileup ' + str(args.pileup)            
         if args.recPositions and args.pileup:
             common_fccsw_command += ' --prefixCollections merged '
@@ -498,6 +498,8 @@ if __name__=="__main__":
             common_fccsw_command += ' --winEta ' + str(args.winEta) + ' --winPhi ' + str(args.winPhi) + ' --enThreshold ' + str(args.enThreshold) + ' '
         if args.recTopoClusters:
             common_fccsw_command += ' --sigma1 ' + str(args.sigma1) + ' --sigma2 ' + str(args.sigma2) + ' --sigma3 ' + str(args.sigma3) + ' '
+            if args.pileup:
+                common_fccsw_command += ' --pileup ' + str(args.pileup)
         print '-------------------------------------'
         print common_fccsw_command
         print '-------------------------------------'

--- a/python/send.py
+++ b/python/send.py
@@ -324,7 +324,7 @@ if __name__=="__main__":
             pt = args.pt
             print "LHE: ", LHE
             print "jet pt: ", pt
-            job_dir += "etaTo0.5/" + str(pt) + "GeV/"
+            job_dir += "etaTo"+str(args.etaMax)+"/" + str(pt) + "GeV/"
         else:
             LHE = False
             job_dir += "etaFull/"

--- a/python/send.py
+++ b/python/send.py
@@ -499,7 +499,7 @@ if __name__=="__main__":
         if args.recTopoClusters:
             common_fccsw_command += ' --sigma1 ' + str(args.sigma1) + ' --sigma2 ' + str(args.sigma2) + ' --sigma3 ' + str(args.sigma3) + ' '
             if args.pileup:
-                common_fccsw_command += ' --pileup ' + str(args.pileup)
+                common_fccsw_command +=  '--addElectronicsNoise --pileup ' + str(args.pileup)
         print '-------------------------------------'
         print common_fccsw_command
         print '-------------------------------------'

--- a/python/send.py
+++ b/python/send.py
@@ -537,12 +537,7 @@ if __name__=="__main__":
             if not ut.dir_exist(ntup_path):
                 os.system("mkdir -p %s"%(ntup_path))
             frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/clusters.root %s/%s\n'%(ntup_path, outfile))
-            if args.recSlidingWindow:
-                analysis_path = outdir.replace('/reco', '/ana')
-                if not ut.dir_exist(analysis_path):
-                    os.system("mkdir -p %s"%(analysis_path))
-                frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/hist_%s %s\n'%(outfile, analysis_path))
-
+            
         if not args.no_eoscopy:
           frun.write('python /afs/cern.ch/work/h/helsens/public/FCCutils/eoscopy.py $JOBDIR/%s %s\n'%(outfile,outdir))
           frun.write('rm $JOBDIR/%s \n'%(outfile))


### PR DESCRIPTION
This PR depends on PR #32 and therefore should be merged afterwards.

This PR includes:

1. Possibility of running tracker simulation using "hits merging"
    - only creates one hit per module and track and therefore creates in total less tracker hits (nearly factor 2) which reduces the file size
    - the functionality is not yet merged into FCCSW master and therefore runs on a local repository   (inits/trackerMergedHits.py) which is based on v0.9.1 and of which the git repository can be found online[ here](https://github.com/jhrdinka/FCCSW/tree/Digitization_v0.9.1)

example usage:
python python/send.py --singlePart --particle -211 -e 10 -n 1 -N 1 --lsf ---trackerMergedHits --local inits/trackerMergedHits.py --etaMin -6 --etaMax 6

2. Possibility to merge pile up events for the tracker
   - this includes merging of PositionedTrackHit, DigiTrackHitAssociation and, if history is needed, the possibility to also merge the simulated particles (option --mergeSimParticles) 
  - the functionality is not yet merged into FCCSW master and therefore runs on a local repository   (inits/mergePileupTracker.py) which is based on v0.9.1 and of which the git repository can be found online[ here](https://github.com/jhrdinka/FCCSW/tree/DigiTrackerHits_merger_v0.9.1)
  - there is the possibility to only use simulation files from tracker only simulation (option --trackerOnly)

example usage:
python python/send.py --physics --process MinBias -n 1 -N 1 --lsf --mergePileupTracker --pileup 1000 --local inits/mergePileupTracker.py

3. Possibility to merge signal with pile up events produced in 2.
   - this includes merging of PositionedTrackHit, DigiTrackHitAssociation and, if history is needed, the possibility to also merge the simulated particles (option --mergeSimParticles) 
  - the functionality is not yet merged into FCCSW master and therefore runs on a local repository   (inits/mergePileupTracker.py) which is based on v0.9.1 and of which the git repository can be found online[ here](https://github.com/jhrdinka/FCCSW/tree/DigiTrackerHits_merger_v0.9.1)
 - there is the possibility to only use simulation files from tracker only simulation (option -- trackerOnly)

example usage:
python python/send.py --physics --process Zqq --pt 1000 -n 1 -N 1 --lsf --addPileupToSignalTracker  --local inits/mergePileupTracker.py --trackerOnly --pileup 1000

This PR also includes new options to simulate only the tracker (+ a new option --trackerOnly), which is basically the geantSim_trackerPerformance.py, but since there have been differences to the geantSim.py, adapted, so that the input is the same. I did not know, if the other other options are in use like this, this is why I created a new file. However, one can also create only one file.
  
  
