### PR TITLE
update on readme to describe the new flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If **--physics** is used, the following options are possible
    - **--process** to select the type of process. Two types are available
       - from LHE events, this will call a gun that will produce 2 back to back objects, the following keys are available **ljets**, **cjets**, **bjets**, **top**, **Wqq**, **Zqq**, **Hbb**. If this option is used, the pt can also be given using **--pt**
       - from calling pythia8 direcly, thus generating the events at 100TeV, the following keys are available **MinBias**, **Haa**, **Zee**, **H4e**
-      
+      - the eta range is set to plus/minus **--etaMax** for the gun. NOT used for the processes: **MinBias**, **Haa**, **Zee**, **H4e**   
 
 Common options
 ==============
@@ -76,7 +76,7 @@ Simulation
 ```
 python python/send.py --singlePart --particle 11 -e 500 -n 10 -N 1 --condor --etaMin 3.5 --etaMax 3.5
 python python/send.py --singlePart --particle -211 -e 10 -n 10 -N 1 --condor
-python python/send.py --physics --process Zqq --pt 1000 -n 10 -N 1 --lsf
+python python/send.py --physics --process Zqq --pt 1000 --etaMax 1.5 -n 10 -N 1 --lsf
 python python/send.py --physics --process Haa -n 10 -N 1 --lsf
 ```
 
@@ -86,7 +86,7 @@ Reconstruction
 ```
 python python/send.py --singlePart --particle 11 -e 500 -N 1 --condor --etaMin 3.5 --etaMax 3.5 --recSlidingWindow
 python python/send.py --singlePart --particle -211 -e 10 -N 1 --condor --recSlidingWindow --noise
-python python/send.py --physics --process Zqq --pt 1000 -N 1 --lsf --recSlidingWindow
+python python/send.py --physics --process Zqq --pt 1000 --etaMax 1.5 -N 1 --lsf --recSlidingWindow
 python python/send.py --physics --process Haa  -N 1 --lsf --recSlidingWindow
 python python/send.py --local inits/reco.py --singlePart --particle 11 -e 100 -N 1 --condor --recPositions
 ```
@@ -99,7 +99,7 @@ python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --l
 - to include pileup noise, add **--addPileupNoise** and specify the pileup configuration with **--pileup** (choose from: 100, 200, 500 or 1000) 
 ```
 python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --noise
-python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --addPileupNoise --mu 100
+python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --addPileupNoise --pileup 100
 ```
 
 Pileup
@@ -124,9 +124,9 @@ There are several approaches of addressing the pile-up in the detector:
 
 2.1.2 merge signal and PU events that are later passed to the reconstruction (**--addPileupToSignal**)
 ```
-python python/send.py --singlePart --particle -211 -e 10 --addPileupToSignal --pileup 200 --local inits/pileup.py -N 1 --lsf
-python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --noise
-python python/send.py --local inits/reco.py --physics --process MinBias -N 1 --lsf --recTopoClusters --addPileupNoise --mu 100
+python python/send.py --physics --process MinBias --mergePileup --pileup 200 --local inits/reco.py -n 10 -N 1 --lsf
+
+python python/send.py --singlePart --particle -211 -e 10 --addPileupToSignal --pileup 200 --local inits/reco.py -n -1 -N 1 --lsf
 ```
 
 


### PR DESCRIPTION
- --etaMax for eta range in jet simulations
- --pileup used to specify added pileup noise/real pu events
- --local inits/reco.py used to overlay pu, because of --rebase option